### PR TITLE
fix(cache): resume new link

### DIFF
--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -75,7 +75,7 @@ export const ID = {
 export const EXTERNAL_URL = {
   linkedin: 'https://www.linkedin.com/in/krsiakdaniel/',
   github: 'https://github.com/krsiakdaniel/',
-  resume: 'https://drive.google.com/file/d/1b-PWUOauMnFecRuYX7K85xZnwFRMWFR5/view?usp=sharing',
+  resume: 'https://drive.google.com/file/d/1NBBJJaK_zsvqtNiiF388kygQ4gqi0mLD/view?usp=sharing',
 }
 
 // URLs for pages


### PR DESCRIPTION
- Updated resume.
- Old link was causing cache issues and was briefly showing old version of the PDF.