### PR TITLE
refactor(navigation): 👷 default option - no link

### DIFF
--- a/components/layout/page-navigation/DefaultNoLinkNavigation.tsx
+++ b/components/layout/page-navigation/DefaultNoLinkNavigation.tsx
@@ -1,0 +1,21 @@
+import { FC } from 'react'
+
+import { IconArrow } from '@/components/icons/IconArrow'
+
+import { NavigationDirectionEnum } from '@/lib/utils/interfaces/enums'
+
+type DefaultNoLinkNavigationProps = {
+  arrowDirection: NavigationDirectionEnum
+}
+
+const DefaultNoLinkNavigation: FC<DefaultNoLinkNavigationProps> = ({ arrowDirection }) => {
+  return (
+    <div
+      className={`flex w-full font-bold lg:w-1/2 ${arrowDirection === NavigationDirectionEnum.Left ? 'justify-start' : 'justify-end'} rounded-lg border border-dashed border-gray-300 bg-gray-50 p-4 text-center font-bold text-gray-300`}
+    >
+      <IconArrow direction={arrowDirection} />
+    </div>
+  )
+}
+
+export default DefaultNoLinkNavigation

--- a/components/layout/page-navigation/PageNavigation.tsx
+++ b/components/layout/page-navigation/PageNavigation.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react'
 
+import DefaultNoLinkNavigation from '@/components/layout/page-navigation/DefaultNoLinkNavigation'
 import PageNavigationLink from '@/components/layout/page-navigation/PageNavigationLink'
 
 import { NavigationDirectionEnum } from '@/lib/utils/interfaces/enums'
@@ -27,25 +28,27 @@ const PageNavigation: FC<PageNavigationProps> = ({
   return (
     <div className="container mx-auto mt-20 max-w-screen-xl">
       <div className={`group flex flex-col gap-4 md:flex-row ${hasPreviousLink ? 'justify-between' : 'justify-end'}`}>
-        {hasPreviousLink && (
+        {hasPreviousLink ? (
           <PageNavigationLink
             href={linkPrevious}
             text={namePrevious}
             direction={NavigationDirectionEnum.Left}
             dataTestId={dataTestIdPrevious}
             justify="start"
-            widthClass={hasPreviousLink && hasNextLink ? 'lg:w-1/2' : 'lg:w-full'}
           />
+        ) : (
+          <DefaultNoLinkNavigation arrowDirection={NavigationDirectionEnum.Left} />
         )}
-        {hasNextLink && (
+        {hasNextLink ? (
           <PageNavigationLink
             href={linkNext}
             text={nameNext}
             direction={NavigationDirectionEnum.Right}
             dataTestId={dataTestIdNext}
             justify="end"
-            widthClass={hasPreviousLink && hasNextLink ? 'lg:w-1/2' : 'lg:w-full'}
           />
+        ) : (
+          <DefaultNoLinkNavigation arrowDirection={NavigationDirectionEnum.Right} />
         )}
       </div>
     </div>

--- a/components/layout/page-navigation/PageNavigationLink.tsx
+++ b/components/layout/page-navigation/PageNavigationLink.tsx
@@ -10,7 +10,6 @@ type PageNavigationLinkProps = {
   direction?: NavigationDirectionEnum
   dataTestId: string | undefined
   justify: 'start' | 'end'
-  widthClass: string
 }
 
 const PageNavigationLink: FC<PageNavigationLinkProps> = ({
@@ -19,7 +18,6 @@ const PageNavigationLink: FC<PageNavigationLinkProps> = ({
   direction,
   dataTestId,
   justify,
-  widthClass,
 }): JSX.Element => {
   const showArrowLeft = direction === NavigationDirectionEnum.Left
   const showArrowRight = direction === NavigationDirectionEnum.Right
@@ -27,7 +25,7 @@ const PageNavigationLink: FC<PageNavigationLinkProps> = ({
   return (
     <a
       href={href}
-      className={`flex w-full items-center justify-${justify} rounded-lg border-violet-300 bg-violet-50 p-4 font-bold text-violet-600 hover:border-violet-300 focus:outline-none focus:ring-4 focus:ring-violet-300 group-hover:text-violet-800 ${widthClass}`}
+      className={`flex w-full items-center justify-${justify} rounded-lg border-violet-300 bg-violet-50 p-4 font-bold text-violet-600 hover:border-violet-300 focus:outline-none focus:ring-4 focus:ring-violet-300 group-hover:text-violet-800 lg:w-1/2`}
       data-testid={dataTestId}
     >
       {showArrowLeft && <IconArrow direction={NavigationDirectionEnum.Left} />}


### PR DESCRIPTION
Issue: `n/a`

---

This pull request includes changes to improve the navigation components by introducing a new `DefaultNoLinkNavigation` component and simplifying the `PageNavigationLink` component.

### Improvements to Navigation Components:

* **New Component Addition:**
  * [`components/layout/page-navigation/DefaultNoLinkNavigation.tsx`](diffhunk://#diff-8ed11bbf54fe97e99b60265228cb92c5bd50645e052546f78bfb0b0797ae8874R1-R21): Added a new `DefaultNoLinkNavigation` component to handle cases where there is no link for navigation.

* **Integration of New Component:**
  * [`components/layout/page-navigation/PageNavigation.tsx`](diffhunk://#diff-cb0b0ce1a6fdc07694aa9debf650edb22e224b2696edca19775959536a21e5c1R3): Integrated the `DefaultNoLinkNavigation` component to handle scenarios where there are no previous or next links. [[1]](diffhunk://#diff-cb0b0ce1a6fdc07694aa9debf650edb22e224b2696edca19775959536a21e5c1R3) [[2]](diffhunk://#diff-cb0b0ce1a6fdc07694aa9debf650edb22e224b2696edca19775959536a21e5c1L30-R51)

* **Simplification of Existing Component:**
  * [`components/layout/page-navigation/PageNavigationLink.tsx`](diffhunk://#diff-b370ec18d9e24af30a0d9efb662da1ee1fa75c46a3553968bd9c6451b486510bL13): Removed the `widthClass` prop and simplified the class assignment by setting a fixed width class. [[1]](diffhunk://#diff-b370ec18d9e24af30a0d9efb662da1ee1fa75c46a3553968bd9c6451b486510bL13) [[2]](diffhunk://#diff-b370ec18d9e24af30a0d9efb662da1ee1fa75c46a3553968bd9c6451b486510bL22-R28)