### PR TITLE
fix(resume): 🐛 layout issue on career list

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -66,8 +66,8 @@ Attach relevant screenshots if applicable.
 
 ### Before
 
-...
+![Before](https://placehold.co/400x200?text=Before+Screenshot)
 
 ### After
 
-...
+![After](https://placehold.co/400x200?text=After+Screenshot)

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -50,8 +50,8 @@ Attach relevant screenshots if applicable.
 
 ### Before
 
-...
+![Before](https://placehold.co/400x200?text=Before+Screenshot)
 
 ### After
 
-...
+![After](https://placehold.co/400x200?text=After+Screenshot)

--- a/.github/ISSUE_TEMPLATE/refactoring.md
+++ b/.github/ISSUE_TEMPLATE/refactoring.md
@@ -51,3 +51,11 @@ code_example
 ## Screenshots
 
 Attach relevant screenshots if applicable.
+
+### Before
+
+![Before](https://placehold.co/400x200?text=Before+Screenshot)
+
+### After
+
+![After](https://placehold.co/400x200?text=After+Screenshot)

--- a/.github/ISSUE_TEMPLATE/test-e2e-playwright.md
+++ b/.github/ISSUE_TEMPLATE/test-e2e-playwright.md
@@ -50,8 +50,8 @@ Attach relevant screenshots if applicable.
 
 ### Before
 
-...
+![Before](https://placehold.co/400x200?text=Before+Screenshot)
 
 ### After
 
-...
+![After](https://placehold.co/400x200?text=After+Screenshot)

--- a/.github/ISSUE_TEMPLATE/test-unit-jest.md
+++ b/.github/ISSUE_TEMPLATE/test-unit-jest.md
@@ -50,8 +50,8 @@ Attach relevant screenshots if applicable.
 
 ### Before
 
-...
+![Before](https://placehold.co/400x200?text=Before+Screenshot)
 
 ### After
 
-...
+![Before](https://placehold.co/400x200?text=Before+Screenshot)

--- a/components/pages/resume/CareerPathList.tsx
+++ b/components/pages/resume/CareerPathList.tsx
@@ -12,11 +12,15 @@ const CareerPathList: FC = (): JSX.Element => {
     <List>
       {jobs.map((job) => (
         <ListItem key={job.id}>
-          <span className="mr-1 font-bold">{job.title}</span>
-          {' · '}
-          <span className="ml-1">
-            {job.duration} {formatExperienceMonthsYears({ duration: job.duration, unit: job.unit })}
-          </span>
+          <div>
+            <p>
+              <span className="font-bold">{job.title}</span>
+              <span className="hidden sm:inline">
+                {' · '}
+                {job.duration} {formatExperienceMonthsYears({ duration: job.duration, unit: job.unit })}
+              </span>
+            </p>
+          </div>
         </ListItem>
       ))}
     </List>


### PR DESCRIPTION
Issue: #332 

---

This pull request includes changes to the `CareerPathList` component in the `components/pages/resume/CareerPathList.tsx`

**fix: 🐛 Layout and readability improvements:**

* [`components/pages/resume/CareerPathList.tsx`](diffhunk://#diff-58faf7143866ba5ec86cee75a79a60779c11251b22c8d5ba188e31acaec43a34L15-R23): Modified the `CareerPathList` component to wrap job titles and durations in a `div` and `p` element, making the job duration hidden on small screens and visible on larger screens.

**docs: 📝 Updates to issue templates:**

* [`.github/ISSUE_TEMPLATE/bug-report.md`](diffhunk://#diff-5870a741e2fa8d0b03a88d7b036d408ee7e6954051fcc5d7978269bf6d1ff242L69-R73): Added "Before" and "After" screenshot placeholders to the bug report template.
* [`.github/ISSUE_TEMPLATE/feature-request.md`](diffhunk://#diff-e9349fad824a042e877a9a2f15d475a1fb691346b70711c916e495542e2e6e5eL53-R57): Added "Before" and "After" screenshot placeholders to the feature request template.
* [`.github/ISSUE_TEMPLATE/refactoring.md`](diffhunk://#diff-a5b6bf3e286b9ad65dd65c625a71884f23649e36008ddb428399e5babd55029fR54-R61): Added "Before" and "After" screenshot placeholders to the refactoring template.
* [`.github/ISSUE_TEMPLATE/test-e2e-playwright.md`](diffhunk://#diff-636a1e5b508e246d8a50dde509e499402f3fc4bdc899683fa0634a11849d4ca5L53-R57): Added "Before" and "After" screenshot placeholders to the end-to-end test template.
* [`.github/ISSUE_TEMPLATE/test-unit-jest.md`](diffhunk://#diff-df649a6f89b11001691c1cc43eda53b318ebeac25d4056da2b02b318478b4381L53-R57): Added "Before" and "After" screenshot placeholders to the unit test template.