### PR TITLE
refactor(resume): 👷 download pdf and cta linkedin

### DIFF
--- a/__tests__/playwright/lib/utils/constants/ids/dataTestIds.ts
+++ b/__tests__/playwright/lib/utils/constants/ids/dataTestIds.ts
@@ -168,6 +168,10 @@ const CALL_TO_ACTION = {
   linkLinkedIn: 'call-to-action-link-linkedin',
 }
 
+const RESUME = {
+  downloadLinkPlainText: 'resume-plain-text-view-pdf',
+}
+
 export const DATA_TEST_IDS = {
   breadcrumbs: 'breadcrumbs',
   gallery: 'gallery',
@@ -179,4 +183,5 @@ export const DATA_TEST_IDS = {
   projects: PROJECTS,
   pagesLinks: PAGES_LINKS,
   callToAction: CALL_TO_ACTION,
+  resume: RESUME,
 }

--- a/__tests__/playwright/pages/resume/resumeDownloadTextLink.spec.ts
+++ b/__tests__/playwright/pages/resume/resumeDownloadTextLink.spec.ts
@@ -1,0 +1,43 @@
+import { Browser, BrowserContext, Page, test } from '@playwright/test'
+
+import { checkLink } from '@/__tests__/playwright/lib/utils/helpers/checkLink'
+import { setupBrowser, setupPage, teardownContext } from '@/__tests__/playwright/lib/utils/helpers/setup'
+
+let browser: Browser
+let context: BrowserContext
+let page: Page
+
+// Setup browser and context before all tests
+test.beforeAll(async () => {
+  const setup = await setupBrowser()
+  browser = setup.browser
+  context = setup.context
+  page = setup.page
+})
+
+// Close the browser after all tests
+test.afterAll(async () => {
+  await browser.close()
+})
+
+// Setup a new context and page before each test
+test.beforeEach(async () => {
+  context = await browser.newContext()
+  page = await setupPage(context, '/resume')
+})
+
+// Close the context after each test
+test.afterEach(async () => {
+  await teardownContext(context)
+})
+
+test.describe('Resume page', () => {
+  // Test to check if the Resume link in the text 'Download Resume in PDF' is correct
+  test('should have the correct Resume link', async () => {
+    await checkLink(
+      page,
+      'resume-plain-text-view-pdf',
+      'https://drive.google.com/file/d/1NBBJJaK_zsvqtNiiF388kygQ4gqi0mLD/view',
+    )
+  })
+})

--- a/app/work-experience/page.tsx
+++ b/app/work-experience/page.tsx
@@ -38,6 +38,7 @@ const ProjectsWork: FC = (): JSX.Element => {
         {/* REACT */}
         <ProjectSection sectionId={ID.section.react} sectionText="React" projectData={projectsWorkReact} />
 
+        {/* CTA */}
         <CallToActionResume />
 
         {/* FRONT END */}
@@ -98,6 +99,7 @@ const ProjectsWork: FC = (): JSX.Element => {
           />
         </div>
 
+        {/* CTA */}
         <CallToActionResume />
       </ProjectsOverviewLayout>
 

--- a/components/pages/resume/ResumePlainText.tsx
+++ b/components/pages/resume/ResumePlainText.tsx
@@ -1,31 +1,32 @@
 import { FC } from 'react'
 
+import ResumePlainTextLink from '@/components/pages/resume/ResumePlainTextLink'
+import ResumePlainTextPage from '@/components/pages/resume/ResumePlainTextPage'
+import CallToActionLinkedIn from '@/components/shared/call-to-action/CallToActionLinkedIn'
+
 import {
   resumePlainTextPage1,
   resumePlainTextPage2,
   resumePlainTextPage3,
 } from '@/lib/data/pages/resume/resumePlainText'
 
-type ResumePlainTextPageProps = {
-  content: string
-}
-
-const ResumePlainTextPage: FC<ResumePlainTextPageProps> = ({ content }): JSX.Element => (
-  <div className="mt-8 w-full">
-    <pre className="text-md whitespace-pre-wrap rounded-lg bg-gray-100 p-8 font-mono">{content}</pre>
-  </div>
-)
-
 const ResumePlainText: FC = (): JSX.Element => (
   <>
     <div className="mt-16 border-b pb-2 text-2xl font-bold uppercase">Resume In Plain Text</div>
     <div>
-      <p className="mt-4 text-lg text-neutral-600">Learn more about my professional experience</p>
+      <p className="mt-4 text-lg text-neutral-600">
+        Read more about my professional experience. Or <ResumePlainTextLink /> 😉
+      </p>
     </div>
 
     <div>
       <ResumePlainTextPage content={resumePlainTextPage1} />
-      <ResumePlainTextPage content={resumePlainTextPage2} />
+
+      <CallToActionLinkedIn />
+
+      <div className="mt-16">
+        <ResumePlainTextPage content={resumePlainTextPage2} />
+      </div>
       <ResumePlainTextPage content={resumePlainTextPage3} />
     </div>
   </>

--- a/components/pages/resume/ResumePlainTextLink.tsx
+++ b/components/pages/resume/ResumePlainTextLink.tsx
@@ -1,0 +1,22 @@
+import { FC } from 'react'
+
+import { TEXT } from '@/localization/english'
+
+import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/dataTestIds'
+import { EXTERNAL_URL } from '@/lib/utils/constants/urls/externalUrls'
+
+const ResumePlainTextLink: FC = (): JSX.Element => {
+  return (
+    <a
+      href={EXTERNAL_URL.resume.resumeViewPDF}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-violet-600 underline hover:no-underline"
+      data-testid={DATA_TEST_IDS.resume.downloadLinkPlainText}
+    >
+      {TEXT.downloadResume}
+    </a>
+  )
+}
+
+export default ResumePlainTextLink

--- a/components/pages/resume/ResumePlainTextPage.tsx
+++ b/components/pages/resume/ResumePlainTextPage.tsx
@@ -1,0 +1,15 @@
+import { FC } from 'react'
+
+type ResumePlainTextPageProps = {
+  content: string
+}
+
+const ResumePlainTextPage: FC<ResumePlainTextPageProps> = ({ content }): JSX.Element => {
+  return (
+    <div className="mt-8 w-full">
+      <pre className="text-md whitespace-pre-wrap rounded-lg bg-gray-100 p-8 font-mono">{content}</pre>
+    </div>
+  )
+}
+
+export default ResumePlainTextPage

--- a/components/shared/call-to-action/CallToActionResumeDownload.tsx
+++ b/components/shared/call-to-action/CallToActionResumeDownload.tsx
@@ -4,6 +4,7 @@ import CallToAction from '@/components/shared/call-to-action/CallToAction'
 
 import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/dataTestIds'
 import { EXTERNAL_URL } from '@/lib/utils/constants/urls/externalUrls'
+import { TEXT } from '@/localization/english'
 
 const CallToActionResumeDownload: FC = (): JSX.Element => {
   return (
@@ -12,7 +13,7 @@ const CallToActionResumeDownload: FC = (): JSX.Element => {
       heading="Download My Resume"
       description="Get a PDF copy of my resume to learn more about my professional experience."
       link={EXTERNAL_URL.resume.resumeViewPDF}
-      linkText="💾 Download Resume in PDF"
+      linkText={`💾 ${TEXT.downloadResume}`}
       dataTestId={DATA_TEST_IDS.callToAction.linkResumeDownload}
       icon="💾"
       isLinkExternal

--- a/localization/english.ts
+++ b/localization/english.ts
@@ -45,6 +45,7 @@ export const HOME = {
 
 export const RESUME = {
   resume: '📝 Resume',
+  downloadResume: 'Download Resume in PDF',
 }
 
 export const TESTIMONIALS = {


### PR DESCRIPTION
Issue: `n/a`

---

This pull request introduces several changes to the resume-related functionality and tests in the codebase. 

## Resume-related updates

* [`__tests__/playwright/lib/utils/constants/ids/dataTestIds.ts`](diffhunk://#diff-c5eed5bbb0decaf7caa72750517e07c34176a84b055962effa26c20d336046ddR171-R174): Added a new constant `RESUME` with `downloadLinkPlainText` and included it in `DATA_TEST_IDS`. [[1]](diffhunk://#diff-c5eed5bbb0decaf7caa72750517e07c34176a84b055962effa26c20d336046ddR171-R174) [[2]](diffhunk://#diff-c5eed5bbb0decaf7caa72750517e07c34176a84b055962effa26c20d336046ddR186)
* [`components/pages/resume/ResumePlainText.tsx`](diffhunk://#diff-8a04820590a32181935df09e6870916a29f9e887211ee509918aa1ff9a11aea1R3-R29): Refactored the component to include `ResumePlainTextLink`, `ResumePlainTextPage`, and `CallToActionLinkedIn`. Removed the inline definition of `ResumePlainTextPage`.
* [`components/pages/resume/ResumePlainTextLink.tsx`](diffhunk://#diff-fda46ff9e5ee208c6995dd5043a8ed7593c59839fa0f2eeb3e221e4cc768c958R1-R22): Created a new component to render the resume download link with appropriate attributes and data test ID.
* [`components/pages/resume/ResumePlainTextPage.tsx`](diffhunk://#diff-286f17e74bb06f9210b0175b79c2785f6c103a6e45f286038b12f73ef402ccdcR1-R15): Created a new component to render the plain text content of the resume.

## Testing enhancements

* [`__tests__/playwright/pages/resume/resumeDownloadTextLink.spec.ts`](diffhunk://#diff-38330b1b2064991949c32655081fd16f9e24cea754008e043df8e476c032fa31R1-R43): Added a new test suite to verify the correctness of the resume download link on the resume page.

## Localization updates

* [`localization/english.ts`](diffhunk://#diff-56f60b3fd203762cbec540ddf7d4e9c68ead8992ead4bacec6f9a44913368ef7R48): Added a new localization string `downloadResume` for the resume download link text.

## Call-to-action component updates

* [`components/shared/call-to-action/CallToActionResumeDownload.tsx`](diffhunk://#diff-6836da6ae40438fc16464adea64f2244106f889e1ccc3f00a31b126a9c1c0738R7): Updated the `linkText` to use the new localization string `TEXT.downloadResume`. [[1]](diffhunk://#diff-6836da6ae40438fc16464adea64f2244106f889e1ccc3f00a31b126a9c1c0738R7) [[2]](diffhunk://#diff-6836da6ae40438fc16464adea64f2244106f889e1ccc3f00a31b126a9c1c0738L15-R16)

## Miscellaneous updates

* [`app/work-experience/page.tsx`](diffhunk://#diff-ac1ae2a09ffe6e73f3a76a2eece4890b351d7f24eddc7771d82b9c2de693612bR41): Added `CallToActionResume` components to the work experience page. [[1]](diffhunk://#diff-ac1ae2a09ffe6e73f3a76a2eece4890b351d7f24eddc7771d82b9c2de693612bR41) [[2]](diffhunk://#diff-ac1ae2a09ffe6e73f3a76a2eece4890b351d7f24eddc7771d82b9c2de693612bR102)
