### PR TITLE
refactor(urls): 👷 page urls exports

### DIFF
--- a/__tests__/jest/generateUrls.test.ts
+++ b/__tests__/jest/generateUrls.test.ts
@@ -1,5 +1,3 @@
-import { URL_PERSONAL_PROJECTS } from '@/lib/utils/constants/urls/pageUrls'
-
 import { getUrlPersonalProject, getUrlWorkExperience } from '@/lib/utils/helpers/getPageUrls'
 
 describe('getUrlWorkExperience', () => {
@@ -9,12 +7,26 @@ describe('getUrlWorkExperience', () => {
     const result = getUrlWorkExperience(company)
     expect(result).toBe(expectedUrl)
   })
+
+  it('should handle empty company name', () => {
+    const company = ''
+    const expectedUrl = `/work-experience/`
+    const result = getUrlWorkExperience(company)
+    expect(result).toBe(expectedUrl)
+  })
 })
 
 describe('getUrlPersonalProject', () => {
   it('should return the correct URL for a given project', () => {
     const project = 'exampleProject'
-    const expectedUrl = `${URL_PERSONAL_PROJECTS}/${project}`
+    const expectedUrl = `/personal-projects/${project}`
+    const result = getUrlPersonalProject(project)
+    expect(result).toBe(expectedUrl)
+  })
+
+  it('should handle empty project name', () => {
+    const project = ''
+    const expectedUrl = `/personal-projects/`
     const result = getUrlPersonalProject(project)
     expect(result).toBe(expectedUrl)
   })

--- a/lib/utils/constants/urls/pageUrls.ts
+++ b/lib/utils/constants/urls/pageUrls.ts
@@ -1,18 +1,12 @@
 import { getUrlPersonalProject, getUrlWorkExperience } from '@/lib/utils/helpers/getPageUrls'
 
-const URL_WEBSITE_PRODUCTION = 'https://krsiak.cz'
-
-// TODO: refactor, remove export, update all usages in files
-export const URL_WORK_EXPERIENCE = '/work-experience'
-export const URL_PERSONAL_PROJECTS = '/personal-projects'
-
 export const PAGES_URL = {
-  websiteProduction: URL_WEBSITE_PRODUCTION,
+  websiteProduction: 'https://krsiak.cz',
   localhost: 'http://localhost:3000',
   home: '/',
   resume: '/resume',
   work: {
-    mainUrl: URL_WORK_EXPERIENCE,
+    mainUrl: '/work-experience',
     kooperativa: getUrlWorkExperience('kooperativa'),
     smartsupp: {
       dashboard: getUrlWorkExperience('smartsupp-dashboard'),
@@ -24,7 +18,7 @@ export const PAGES_URL = {
     moravia: getUrlWorkExperience('moravia'),
   },
   personal: {
-    mainUrl: URL_PERSONAL_PROJECTS,
+    mainUrl: '/personal-projects',
     krsiak: getUrlPersonalProject('krsiak'),
     cryptoMania: getUrlPersonalProject('cryptomania'),
   },

--- a/lib/utils/helpers/breadcrumbs/getBreadcrumbsPersonal.ts
+++ b/lib/utils/helpers/breadcrumbs/getBreadcrumbsPersonal.ts
@@ -1,4 +1,4 @@
-import { URL_PERSONAL_PROJECTS } from '@/lib/utils/constants/urls/pageUrls'
+import { PAGES_URL } from '@/lib/utils/constants/urls/pageUrls'
 
 import { TEXT } from '@/localization/english'
 
@@ -14,7 +14,7 @@ import { BreadCrumbsType } from '@/lib/utils/interfaces/types'
 
 export const getBreadcrumbsPersonal = (level2Url: string, level2Text: string): BreadCrumbsType => {
   return {
-    level1Url: URL_PERSONAL_PROJECTS,
+    level1Url: PAGES_URL.personal.mainUrl,
     level1Text: TEXT.personalProjects,
     level2Url,
     level2Text,

--- a/lib/utils/helpers/breadcrumbs/getBreadcrumbsWork.ts
+++ b/lib/utils/helpers/breadcrumbs/getBreadcrumbsWork.ts
@@ -1,4 +1,4 @@
-import { URL_WORK_EXPERIENCE } from '@/lib/utils/constants/urls/pageUrls'
+import { PAGES_URL } from '@/lib/utils/constants/urls/pageUrls'
 
 import { TEXT } from '@/localization/english'
 
@@ -14,7 +14,7 @@ import { BreadCrumbsType } from '@/lib/utils/interfaces/types'
 
 export const getBreadcrumbsWork = (level2Url: string, level2Text: string): BreadCrumbsType => {
   return {
-    level1Url: URL_WORK_EXPERIENCE,
+    level1Url: PAGES_URL.work.mainUrl,
     level1Text: TEXT.workExperience,
     level2Url,
     level2Text,

--- a/lib/utils/helpers/getGoBackLink.ts
+++ b/lib/utils/helpers/getGoBackLink.ts
@@ -1,4 +1,4 @@
-import { PAGES_URL, URL_PERSONAL_PROJECTS, URL_WORK_EXPERIENCE } from '@/lib/utils/constants/urls/pageUrls'
+import { PAGES_URL } from '@/lib/utils/constants/urls/pageUrls'
 
 import { GoBackLinkEnum } from '@/lib/utils/interfaces/enums'
 
@@ -13,9 +13,9 @@ import { GoBackLinkEnum } from '@/lib/utils/interfaces/enums'
 export const getGoBackLinkID = (goBackLink: GoBackLinkEnum, sectionID: string): string => {
   switch (goBackLink) {
     case 'work':
-      return `${URL_WORK_EXPERIENCE}/#${sectionID}`
+      return `${PAGES_URL.work.mainUrl}/#${sectionID}`
     case 'personal':
-      return `${URL_PERSONAL_PROJECTS}/#${sectionID}`
+      return `${PAGES_URL.personal.mainUrl}/#${sectionID}`
     default:
       return PAGES_URL.home
   }

--- a/lib/utils/helpers/getPageUrls.ts
+++ b/lib/utils/helpers/getPageUrls.ts
@@ -1,5 +1,3 @@
-import { URL_PERSONAL_PROJECTS, URL_WORK_EXPERIENCE } from '@/lib/utils/constants/urls/pageUrls'
-
 /**
  * Generates the URL for a specific work experience.
  *
@@ -8,7 +6,7 @@ import { URL_PERSONAL_PROJECTS, URL_WORK_EXPERIENCE } from '@/lib/utils/constant
  */
 
 export const getUrlWorkExperience = (company: string): string => {
-  return `${URL_WORK_EXPERIENCE}/${company}`
+  return `/work-experience/${company}`
 }
 
 /**
@@ -19,5 +17,5 @@ export const getUrlWorkExperience = (company: string): string => {
  */
 
 export const getUrlPersonalProject = (project: string): string => {
-  return `${URL_PERSONAL_PROJECTS}/${project}`
+  return `/personal-projects/${project}`
 }


### PR DESCRIPTION
Issue: #362 

---

This pull request includes several changes to refactor the URL constants and update their usage across the codebase. The main goal is to simplify the URL management by removing redundant constants and directly using the URLs in the code.

Refactoring URL constants:

* Removed `URL_PERSONAL_PROJECTS` and `URL_WORK_EXPERIENCE` constants and updated their usages to use direct URL strings in `lib/utils/constants/urls/pageUrls.ts`. [[1]](diffhunk://#diff-4b33e614c2fbc21d5c6d786a6b7a2f14b0b9ac94922f64618c571dbd7fcc107dL3-R9) [[2]](diffhunk://#diff-4b33e614c2fbc21d5c6d786a6b7a2f14b0b9ac94922f64618c571dbd7fcc107dL27-R21)
* Updated the breadcrumb helper functions to use the new URL structure in `lib/utils/helpers/breadcrumbs/getBreadcrumbsPersonal.ts` and `lib/utils/helpers/breadcrumbs/getBreadcrumbsWork.ts`. [[1]](diffhunk://#diff-4d837651ab655c6319b3bf63c7ef042b3d789aec474bf6fb2849fa823246e65dL1-R1) [[2]](diffhunk://#diff-4d837651ab655c6319b3bf63c7ef042b3d789aec474bf6fb2849fa823246e65dL17-R17) [[3]](diffhunk://#diff-56e353ecf2e0ff1a7f5f0c58a8c6c22efb80fa5a6cfb85dbc6ddfcdad56f8675L1-R1) [[4]](diffhunk://#diff-56e353ecf2e0ff1a7f5f0c58a8c6c22efb80fa5a6cfb85dbc6ddfcdad56f8675L17-R17)
* Modified the `getGoBackLinkID` function to use the updated URL structure in `lib/utils/helpers/getGoBackLink.ts`. [[1]](diffhunk://#diff-5c617dcd77134e40348eb3a48232882bc12399b784c52adfb051ddd5c27f8c13L1-R1) [[2]](diffhunk://#diff-5c617dcd77134e40348eb3a48232882bc12399b784c52adfb051ddd5c27f8c13L16-R18)
* Updated the `getUrlPersonalProject` and `getUrlWorkExperience` helper functions to use direct URL strings in `lib/utils/helpers/getPageUrls.ts`. [[1]](diffhunk://#diff-10c4d100118c965b71e115c66ccde12d448c285cf53677546c895cb2c250ae69L1-L2) [[2]](diffhunk://#diff-10c4d100118c965b71e115c66ccde12d448c285cf53677546c895cb2c250ae69L11-R9) [[3]](diffhunk://#diff-10c4d100118c965b71e115c66ccde12d448c285cf53677546c895cb2c250ae69L22-R20)

Enhancements to test cases:

* Added new test cases to handle empty project and company names in `__tests__/jest/generateUrls.test.ts`.