### PR TITLE
refactor(footer): 👷 remove banner and use QR vcard

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,6 @@ import PageContainer from '@/components/layout/PageContainer'
 import Companies from '@/components/pages/home/Companies'
 import WhatIDoMindset from '@/components/pages/home/expertise/MySKills'
 import Hero from '@/components/pages/home/hero/Hero'
-import ScanMyContactQR from '@/components/pages/home/ScanMyContactQR'
 import Skills from '@/components/pages/home/skills/Skills'
 import SkillsMain from '@/components/pages/home/skills/SkillsMain'
 import CallToActionWorkExperience from '@/components/shared/call-to-action/CallToActionWorkExperience'
@@ -31,7 +30,6 @@ const Page: FC = (): JSX.Element => {
       <CallToActionWorkExperience />
       <WhatIDoMindset />
       <Companies />
-      <ScanMyContactQR />
 
       <PageNavigation
         linkNext={PAGES_URL.work.mainUrl}

--- a/components/layout/footer/Footer.tsx
+++ b/components/layout/footer/Footer.tsx
@@ -1,10 +1,10 @@
 import { FC } from 'react'
 
 import DividerInFooter from '@/components/layout/footer/divider/DividerInFooter'
-import FooterBanner from '@/components/layout/footer/FooterBanner'
 import FooterCopyright from '@/components/layout/footer/FooterCopyright'
-import FooterSocialLinks from '@/components/layout/footer/FooterSocialLinks'
 import FooterStatusAndScroll from '@/components/layout/footer/FooterStatusAndScroll'
+import ScanMyContactQR from '@/components/pages/home/ScanMyContactQR'
+
 import { ID } from '@/lib/utils/constants/ids/elementIds'
 
 const Footer: FC = (): JSX.Element => {
@@ -14,9 +14,8 @@ const Footer: FC = (): JSX.Element => {
         <footer>
           <DividerInFooter />
 
-          <div className="mx-auto mt-20 flex w-full flex-col items-center pb-16">
-            <FooterSocialLinks />
-            <FooterBanner />
+          <div className="mx-auto flex w-full flex-col items-center pb-16">
+            <ScanMyContactQR />
             <FooterStatusAndScroll />
             <FooterCopyright />
           </div>

--- a/components/layout/footer/FooterCopyright.tsx
+++ b/components/layout/footer/FooterCopyright.tsx
@@ -9,9 +9,7 @@ import { getCurrentYear } from '@/lib/utils/helpers/getCurrentYear'
 const FooterCopyright: FC = (): JSX.Element => {
   return (
     <div className="mt-4 flex flex-col text-center text-neutral-600">
-      <span className="ml-2" data-testid={DATA_TEST_IDS.footer.copyright}>
-        😼 😺 Copyright ©&nbsp;{getCurrentYear()}
-      </span>
+      <span data-testid={DATA_TEST_IDS.footer.copyright}>😼 😺 Copyright ©&nbsp;{getCurrentYear()}</span>
       <Link
         href={PAGES_URL.home}
         className="underline hover:no-underline"

--- a/components/layout/projects/project-page-detail/Gallery.tsx
+++ b/components/layout/projects/project-page-detail/Gallery.tsx
@@ -3,6 +3,8 @@ import { FC } from 'react'
 
 import Heading3 from '@/components/shared/Heading3'
 
+import { TEXT } from '@/localization/english'
+
 import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/dataTestIds'
 
 import { ImageShowcaseItem } from '@/lib/utils/interfaces/interfaces'
@@ -14,7 +16,7 @@ type GalleryProps = {
 const Gallery: FC<GalleryProps> = ({ imageShowcase }): JSX.Element => {
   return (
     <div className="mt-8">
-      <Heading3>Gallery</Heading3>
+      <Heading3>{TEXT.gallery}</Heading3>
       <p className="mt-4 text-neutral-600">See project screenshots below.</p>
       <div data-testid={DATA_TEST_IDS.gallery}>
         {imageShowcase.map((image) => (

--- a/components/layout/projects/project-page-detail/ProjectInformation.tsx
+++ b/components/layout/projects/project-page-detail/ProjectInformation.tsx
@@ -7,6 +7,8 @@ import Heading3 from '@/components/shared/Heading3'
 import List from '@/components/shared/List'
 import ListItem from '@/components/shared/ListItem'
 
+import { TEXT } from '@/localization/english'
+
 import { Project } from '@/lib/utils/interfaces/interfaces'
 
 type ProjectInformationProps = Pick<
@@ -27,7 +29,7 @@ const ProjectInformation: FC<ProjectInformationProps> = ({
   return (
     <>
       <div className="mt-16">
-        <Heading3>Information</Heading3>
+        <Heading3>{TEXT.information}</Heading3>
         <div className="mt-4">
           {customers && <CustomersCount count={customers} />}
           <List>
@@ -37,14 +39,14 @@ const ProjectInformation: FC<ProjectInformationProps> = ({
       </div>
 
       <div className="mt-8">
-        <Heading3>Skills</Heading3>
+        <Heading3>{TEXT.skills}</Heading3>
         <div className="mt-4">
           <SkillsList skillsOverview={skillsOverview} />
         </div>
       </div>
 
       <div className="mt-8">
-        <Heading3>{hasMoreLinks || hasGithub ? 'Links' : 'Link'}</Heading3>
+        <Heading3>{hasMoreLinks || hasGithub ? TEXT.links : TEXT.link}</Heading3>
         <div className="mt-4">
           <ProjectLinksList projectLinks={projectLinks} linkGitHub={linkGitHub} />
         </div>

--- a/components/pages/home/Companies.tsx
+++ b/components/pages/home/Companies.tsx
@@ -4,7 +4,7 @@ import { FC } from 'react'
 import DividerWithText from '@/components/shared/DividerWithText'
 import Heading2 from '@/components/shared/Heading2'
 
-import { IMAGE_ALT } from '@/localization/english'
+import { DIVIDER_WITH_TEXT, IMAGE_ALT, TEXT } from '@/localization/english'
 
 import ibm from '@/public/images/svg/logo/ibm.svg'
 import komercniBanka from '@/public/images/svg/logo/komercni-banka.svg'
@@ -20,9 +20,9 @@ const Companies: FC = (): JSX.Element => {
   return (
     <section>
       <div className="mt-16">
-        <DividerWithText text="Companies" />
+        <DividerWithText text={DIVIDER_WITH_TEXT.companies} />
         <div className="text-center">
-          <Heading2>Worked For Companies</Heading2>
+          <Heading2>{TEXT.workedForCompanies}</Heading2>
         </div>
 
         <div className={logosWrapperCss}>

--- a/components/pages/home/ScanMyContactQR.tsx
+++ b/components/pages/home/ScanMyContactQR.tsx
@@ -1,19 +1,21 @@
 import Image from 'next/image'
 import { FC } from 'react'
 
+import FooterSocialLinks from '@/components/layout/footer/FooterSocialLinks'
 import DividerWithText from '@/components/shared/DividerWithText'
-import Heading2 from '@/components/shared/Heading2'
 
 import contactQR from '@/public/images/svg/vcard-contact/qr-code-vcard.svg'
 
 const ScanMyContactQR: FC = (): JSX.Element => {
   return (
-    <section className="mt-16">
-      <DividerWithText text="Contact Me" />
-      <div className="text-center">
-        <Heading2>Scan To Add Contact</Heading2>
-      </div>
-      <div className="mt-8 flex justify-center">
+    <div className="flex flex-col items-center justify-center">
+      <section className="mt-16 flex flex-col items-center">
+        <DividerWithText text="My Links" />
+        <FooterSocialLinks />
+      </section>
+
+      <section className="mt-16 flex flex-col items-center">
+        <DividerWithText text="Contact Me" />
         <Image
           src={contactQR}
           width={256}
@@ -21,8 +23,8 @@ const ScanMyContactQR: FC = (): JSX.Element => {
           alt="Contact Me - QR code"
           className="rounded-lg bg-violet-100 p-1 ring-1 ring-violet-300"
         />
-      </div>
-    </section>
+      </section>
+    </div>
   )
 }
 

--- a/components/pages/home/ScanMyContactQR.tsx
+++ b/components/pages/home/ScanMyContactQR.tsx
@@ -4,18 +4,20 @@ import { FC } from 'react'
 import FooterSocialLinks from '@/components/layout/footer/FooterSocialLinks'
 import DividerWithText from '@/components/shared/DividerWithText'
 
+import { DIVIDER_WITH_TEXT } from '@/localization/english'
+
 import contactQR from '@/public/images/svg/vcard-contact/qr-code-vcard.svg'
 
 const ScanMyContactQR: FC = (): JSX.Element => {
   return (
     <div className="flex flex-col items-center justify-center">
-      <section className="mt-16 flex flex-col items-center">
-        <DividerWithText text="My Links" />
+      <section className="mt-16 flex w-full flex-col items-center">
+        <DividerWithText text={DIVIDER_WITH_TEXT.myLinks} />
         <FooterSocialLinks />
       </section>
 
-      <section className="mt-16 flex flex-col items-center">
-        <DividerWithText text="Contact Me" />
+      <section className="mt-16 flex w-full flex-col items-center">
+        <DividerWithText text={DIVIDER_WITH_TEXT.contactMe} />
         <Image
           src={contactQR}
           width={256}

--- a/components/pages/home/expertise/MyMindset.tsx
+++ b/components/pages/home/expertise/MyMindset.tsx
@@ -2,12 +2,14 @@ import { FC } from 'react'
 
 import Heading2 from '@/components/shared/Heading2'
 
+import { TEXT } from '@/localization/english'
+
 import { mindset } from '@/lib/data/pages/home/expertise/mindset'
 
 const MyMindset: FC = (): JSX.Element => {
   return (
     <div className="lg:w-1/2">
-      <Heading2>🥇🚀 I Have Committed Mindset</Heading2>
+      <Heading2>{TEXT.myMindset}</Heading2>
       {mindset.map((skill) => (
         <div className="mt-8" key={skill.id}>
           <p className="mt-4 text-lg text-neutral-600">

--- a/components/pages/home/expertise/MySKills.tsx
+++ b/components/pages/home/expertise/MySKills.tsx
@@ -4,10 +4,12 @@ import MyMindset from '@/components/pages/home/expertise/MyMindset'
 import SkillsForCompany from '@/components/pages/home/skills/SkillsForCompany'
 import DividerWithText from '@/components/shared/DividerWithText'
 
+import { DIVIDER_WITH_TEXT } from '@/localization/english'
+
 const MySKills: FC = (): JSX.Element => {
   return (
     <div className="mt-16">
-      <DividerWithText text="What I Do" />
+      <DividerWithText text={DIVIDER_WITH_TEXT.whatIDo} />
       <div className="mt-5 flex flex-col space-y-20 lg:flex-row lg:space-x-20 lg:space-y-0">
         <SkillsForCompany />
         <MyMindset />

--- a/components/pages/home/skills/Skills.tsx
+++ b/components/pages/home/skills/Skills.tsx
@@ -10,14 +10,14 @@ import {
   iconsWebDevelopmentWithQA,
 } from '@/lib/data/pages/home/skills/skillsGrouped'
 
-import { TEXT } from '@/localization/english'
+import { DIVIDER_WITH_TEXT, TEXT } from '@/localization/english'
 
 import { ID } from '@/lib/utils/constants/ids/elementIds'
 
 const Skills: FC = (): JSX.Element => {
   return (
     <div id={ID.skills} className="mt-16">
-      <DividerWithText text="Skills" />
+      <DividerWithText text={DIVIDER_WITH_TEXT.skills} />
       <div className="mt-5 flex flex-col justify-center space-y-2 lg:flex-row lg:space-x-4 lg:space-y-0">
         <div className="flex flex-col justify-center space-y-2 md:flex-row md:space-x-4 md:space-y-0">
           <SkillsIconGroup icons={iconsWebDevelopment} />

--- a/components/pages/home/skills/SkillsForCompany.tsx
+++ b/components/pages/home/skills/SkillsForCompany.tsx
@@ -2,12 +2,14 @@ import { FC } from 'react'
 
 import Heading2 from '@/components/shared/Heading2'
 
+import { TEXT } from '@/localization/english'
+
 import { skillsInfo } from '@/lib/data/pages/home/expertise/skillsInfo'
 
 const SkillsForCompany: FC = (): JSX.Element => {
   return (
     <div className="lg:w-1/2">
-      <Heading2>💰📈 My Skills For Your Company</Heading2>
+      <Heading2>{TEXT.skillsForCompany}</Heading2>
       {skillsInfo.map((skill) => (
         <div className="mt-8" key={skill.id}>
           <p className="mt-4 text-lg text-neutral-600">

--- a/components/pages/home/skills/SkillsMain.tsx
+++ b/components/pages/home/skills/SkillsMain.tsx
@@ -3,12 +3,14 @@ import { FC } from 'react'
 import DividerWithText from '@/components/shared/DividerWithText'
 import SkillCard from '@/components/shared/SkillCard'
 
+import { DIVIDER_WITH_TEXT } from '@/localization/english'
+
 import { skills } from '@/lib/data/pages/home/skills/skillsMain'
 
 const SkillsMain: FC = (): JSX.Element => {
   return (
     <div className="mt-16">
-      <DividerWithText text="My Main Skills" />
+      <DividerWithText text={DIVIDER_WITH_TEXT.myMainSkills} />
 
       <div className="mt-5 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
         {skills.map((skill) => (

--- a/components/shared/DividerWithText.tsx
+++ b/components/shared/DividerWithText.tsx
@@ -6,8 +6,8 @@ type DividerWithTextProps = {
 
 const DividerWithText: FC<DividerWithTextProps> = ({ text }): JSX.Element => {
   return (
-    <div className="inline-flex w-full items-center justify-center">
-      <hr className="my-8 h-px w-96 border-0 bg-gray-200" />
+    <div className="relative flex w-full items-center justify-center">
+      <hr className="my-8 h-[1px] w-full border-0 bg-gray-200 md:w-96" />
       <span className="absolute left-1/2 -translate-x-1/2 bg-white px-3 text-center font-medium uppercase text-neutral-600">
         {text}
       </span>

--- a/localization/english.ts
+++ b/localization/english.ts
@@ -27,6 +27,15 @@ export const COMMON_VALUES = {
   graphql: 'GraphQL',
 }
 
+export const DIVIDER_WITH_TEXT = {
+  companies: 'Companies',
+  myLinks: 'My Links',
+  contactMe: 'Contact Me',
+  whatIDo: 'What I Do',
+  skills: 'Skills',
+  myMainSkills: 'My Main Skills',
+}
+
 export const SOCIAL_LINKS = {
   linkedIn: 'My LinkedIn',
   resumePDF: 'Resume PDF',
@@ -88,9 +97,23 @@ export const WORK = {
   myJob: 'My job',
 }
 
+export const PROJECT_INFORMATION = {
+  information: 'Information',
+  skills: 'Skills',
+  link: 'Link',
+  links: 'Links',
+}
+
+export const MY_WORK = {
+  workedForCompanies: 'Worked For Companies',
+  myMindset: '🥇🚀 I Have Committed Mindset',
+  skillsForCompany: '💰📈 My Skills For Your Company',
+}
+
 export const MISC = {
   description: 'Description',
   goBack: 'Go back',
+  gallery: 'Gallery',
   skillsIconsNames: `
       ${COMMON_VALUES.javaScript}, ${COMMON_VALUES.typeScript}, ${COMMON_VALUES.react}, ${COMMON_VALUES.next},
       ${COMMON_VALUES.redux}, ${COMMON_VALUES.graphql}, ${COMMON_VALUES.jest}, ${COMMON_VALUES.playwright},
@@ -475,6 +498,8 @@ export const IMAGE_ALT = {
 }
 
 export const TEXT = {
+  ...PROJECT_INFORMATION,
+  ...MY_WORK,
   ...SOCIAL_LINKS,
   ...HOME,
   ...COMPANIES,


### PR DESCRIPTION
Issue: `n/a`

---

This pull request involves reorganizing the `ScanMyContactQR` component and removing some unused components to simplify the layout and improve the user experience. The most important changes include moving the `ScanMyContactQR` component from the home page to the footer, and removing the `FooterBanner` and `FooterSocialLinks` components.

Reorganization of components:

* [`app/page.tsx`](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L8): Removed the `ScanMyContactQR` component from the home page. [[1]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L8) [[2]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L34)
* [`components/layout/footer/Footer.tsx`](diffhunk://#diff-611eaedaa6407f44ed1f4a2c40cf955d8e37de47149102d1e73852f6641eca78L4-R7): Added the `ScanMyContactQR` component to the footer and removed the `FooterBanner` and `FooterSocialLinks` components. [[1]](diffhunk://#diff-611eaedaa6407f44ed1f4a2c40cf955d8e37de47149102d1e73852f6641eca78L4-R7) [[2]](diffhunk://#diff-611eaedaa6407f44ed1f4a2c40cf955d8e37de47149102d1e73852f6641eca78L17-R18)

Simplification of `ScanMyContactQR` component:

* [`components/pages/home/ScanMyContactQR.tsx`](diffhunk://#diff-ea728bd293ca2cd010b29db3c43d946de2301c20a76e20a9d211ea1cd20fa79fR4-R27): Integrated the `FooterSocialLinks` component within the `ScanMyContactQR` component and removed the `Heading2` component.