### PR TITLE
fix(menu): 🐛 mobile - links spacing

### DIFF
--- a/components/layout/PageContainer.tsx
+++ b/components/layout/PageContainer.tsx
@@ -2,12 +2,13 @@ import { FC, ReactNode } from 'react'
 
 type PageContainerProps = {
   id?: string
+  marginTop?: 'mt-0' | 'mt-20'
   children: ReactNode
 }
 
-const PageContainer: FC<PageContainerProps> = ({ id, children }): JSX.Element => {
+const PageContainer: FC<PageContainerProps> = ({ id, marginTop = 'mt-20', children }): JSX.Element => {
   return (
-    <div id={id} className="mt-20 px-5">
+    <div id={id} className={`${marginTop} px-5`}>
       <div className="container mx-auto max-w-screen-xl px-5">{children}</div>
     </div>
   )

--- a/components/layout/footer/Footer.tsx
+++ b/components/layout/footer/Footer.tsx
@@ -2,19 +2,18 @@ import { FC } from 'react'
 
 import DividerInFooter from '@/components/layout/footer/divider/DividerInFooter'
 import FooterContent from '@/components/layout/footer/FooterContent'
+import PageContainer from '@/components/layout/PageContainer'
 
 import { ID } from '@/lib/utils/constants/ids/elementIds'
 
 const Footer: FC = (): JSX.Element => {
   return (
-    <div id={ID.footer} className="mt-20 px-5">
-      <div className="container mx-auto max-w-screen-xl px-5">
-        <footer>
-          <DividerInFooter />
-          <FooterContent />
-        </footer>
-      </div>
-    </div>
+    <PageContainer id={ID.footer}>
+      <footer>
+        <DividerInFooter />
+        <FooterContent />
+      </footer>
+    </PageContainer>
   )
 }
 

--- a/components/layout/header/Header.tsx
+++ b/components/layout/header/Header.tsx
@@ -5,9 +5,10 @@ import { FC, useState } from 'react'
 import { useScrollProgress } from '@/lib/hooks/useScrollProgress'
 
 import Logo from '@/components/layout/header/Logo'
-import Menu from '@/components/layout/header/menu/Menu'
-import MenuToggle from '@/components/layout/header/menu/MenuToggle'
+import MenuDesktop from '@/components/layout/header/menu/MenuDesktop'
+import MenuMobile from '@/components/layout/header/menu/MenuMobile'
 import ScrollProgressBar from '@/components/layout/header/ScrollProgressBar'
+import PageContainer from '@/components/layout/PageContainer'
 
 const Header: FC = (): JSX.Element => {
   const [isOpen, setIsOpen] = useState<boolean>(false)
@@ -18,16 +19,14 @@ const Header: FC = (): JSX.Element => {
   }
 
   return (
-    <header className="sticky top-0 z-20 border-b border-neutral-400 bg-white px-5">
-      <div className="container mx-auto max-w-screen-xl px-5">
+    <header className="sticky top-0 z-20 border-b border-neutral-400 bg-white">
+      <PageContainer marginTop="mt-0">
         <div className="flex items-center justify-between py-3">
           <Logo />
-          {/* desktop menu */}
-          <Menu isMobile={false} />
-          <MenuToggle isOpen={isOpen} handleMenuToggle={handleMenuToggle} />
+          <MenuDesktop isOpen={isOpen} handleMenuToggle={handleMenuToggle} />
         </div>
-        {isOpen && <Menu isMobile={true} />}
-      </div>
+        {isOpen && <MenuMobile />}
+      </PageContainer>
 
       <ScrollProgressBar scroll={scroll} />
     </header>

--- a/components/layout/header/menu/Menu.tsx
+++ b/components/layout/header/menu/Menu.tsx
@@ -6,11 +6,15 @@ import { pagesLinks } from '@/lib/data/layout/pagesLinks'
 import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/dataTestIds'
 import { ARIA_LABELS } from '@/lib/utils/constants/ariaLabels'
 import { ID } from '@/lib/utils/constants/ids/elementIds'
-import { getMenuLinkCSS } from '@/lib/utils/helpers/menu/getMenuLinkCSS'
+
 import { getMenuLinkID } from '@/lib/utils/helpers/menu/getMenuLinkID'
 
 type MenuProps = {
   isMobile: boolean
+}
+
+const getMenuLinkCSS = (isMobile: boolean): string => {
+  return isMobile ? 'block border-b  border-neutral-100 py-3 pl-3 pr-4 hover:bg-neutral-50' : 'text-md cursor-pointer'
 }
 
 const Menu: FC<MenuProps> = ({ isMobile }): JSX.Element => {

--- a/components/layout/header/menu/MenuDesktop.tsx
+++ b/components/layout/header/menu/MenuDesktop.tsx
@@ -1,0 +1,20 @@
+import { FC } from 'react'
+
+import Menu from '@/components/layout/header/menu/Menu'
+import MenuToggle from '@/components/layout/header/menu/MenuToggle'
+
+type MenuDesktopProps = {
+  isOpen: boolean
+  handleMenuToggle: () => void
+}
+
+const MenuDesktop: FC<MenuDesktopProps> = ({ isOpen, handleMenuToggle }): JSX.Element => {
+  return (
+    <>
+      <Menu isMobile={false} />
+      <MenuToggle isOpen={isOpen} handleMenuToggle={handleMenuToggle} />
+    </>
+  )
+}
+
+export default MenuDesktop

--- a/components/layout/header/menu/MenuMobile.tsx
+++ b/components/layout/header/menu/MenuMobile.tsx
@@ -1,0 +1,9 @@
+import { FC } from 'react'
+
+import Menu from '@/components/layout/header/menu/Menu'
+
+const MenuMobile: FC = (): JSX.Element => {
+  return <Menu isMobile={true} />
+}
+
+export default MenuMobile

--- a/lib/utils/helpers/menu/getMenuLinkCSS.ts
+++ b/lib/utils/helpers/menu/getMenuLinkCSS.ts
@@ -1,3 +1,0 @@
-export const getMenuLinkCSS = (isMobile: boolean): string => {
-  return isMobile ? 'block border-b border-neutral-100 py-2 pl-3 pr-4 hover:bg-neutral-50' : 'text-md cursor-pointer'
-}


### PR DESCRIPTION
Issue: #371 

---

Fix:

* CSS spacing for mobile menu links.

Refactoring and componentization:

* [`components/layout/PageContainer.tsx`](diffhunk://#diff-5e3c621fad45ee0b86a4688d7fc36cf61c85f1a208132a21841e10ba279ce00dR5-R11): Added a `marginTop` prop to allow customizable top margin and used this prop in the `PageContainer` component.
* [`components/layout/footer/Footer.tsx`](diffhunk://#diff-611eaedaa6407f44ed1f4a2c40cf955d8e37de47149102d1e73852f6641eca78R5-R16): Replaced the existing layout structure with the new `PageContainer` component to simplify the footer layout.
* [`components/layout/header/Header.tsx`](diffhunk://#diff-1d4e4c08770ba9acb1831f21a6bbc80a03af9f556a0f6d2dac260d8478d7934dL8-R11): Updated the header to use the `PageContainer` component and split the menu into `MenuDesktop` and `MenuMobile` components for better separation of concerns. [[1]](diffhunk://#diff-1d4e4c08770ba9acb1831f21a6bbc80a03af9f556a0f6d2dac260d8478d7934dL8-R11) [[2]](diffhunk://#diff-1d4e4c08770ba9acb1831f21a6bbc80a03af9f556a0f6d2dac260d8478d7934dL21-R29)
* [`components/layout/header/menu/MenuDesktop.tsx`](diffhunk://#diff-983d18aa1f5e801d768b75ff203baef42da43b975fd4f0fe35556028a7e74f94R1-R20): Created a new `MenuDesktop` component to handle the desktop menu and menu toggle.
* [`components/layout/header/menu/MenuMobile.tsx`](diffhunk://#diff-7eaa6de1c60605e040e6a3233b4d66d699654bd69ad197246a3e7d3e84a651eeR1-R9): Created a new `MenuMobile` component to handle the mobile menu.

Removal of redundant code:

* [`lib/utils/helpers/menu/getMenuLinkCSS.ts`](diffhunk://#diff-8bdd7b5860f85986dca73649138776429dbfd74aa1bc9399e11306e359cea9b9L1-L3): Removed the `getMenuLinkCSS` function as it was moved directly into the `Menu` component.
* [`components/layout/header/menu/Menu.tsx`](diffhunk://#diff-9f2fe9b6ad371d0c235fc0c17af8197ac7e86386d9ed4085189f4259307d646eL9-R19): Inlined the `getMenuLinkCSS` function within the `Menu` component to simplify the code.