### PR TITLE
refactor(divider): 👷 order sun ☀️ and moon 🌔 in footer

### DIFF
--- a/components/layout/footer/divider/DividerInFooter.tsx
+++ b/components/layout/footer/divider/DividerInFooter.tsx
@@ -22,21 +22,19 @@ import TheSun from '@/components/layout/footer/divider/TheSun'
  *
  */
 
-// FIXME: sunrise is in the east = right, sunset is in the west = left, change the order of the elements and gradients
-
 const sharedCSS = 'mx-2 h-1 w-full flex-1'
 
-const sunRiseToNoon = <div className={`bg-gradient-to-r from-yellow-400 via-sky-300 to-green-500 ${sharedCSS}`} />
-const noonToSunSet = <div className={`bg-gradient-to-r from-green-500 via-blue-700 to-gray-800 ${sharedCSS}`} />
+const noonToSunSet = <div className={`bg-gradient-to-l from-sky-300 via-blue-400 to-gray-500 ${sharedCSS}`} />
+const sunRiseToNoon = <div className={`bg-gradient-to-l from-red-500 via-yellow-400 to-sky-300 ${sharedCSS}`} />
 
 const DividerWithGradient: FC = () => {
   return (
     <div className="flex w-full items-center justify-between">
-      <TheSun />
-      {sunRiseToNoon}
-      <ManWalkingInForest />
-      {noonToSunSet}
       <TheMoon />
+      {noonToSunSet}
+      <ManWalkingInForest />
+      {sunRiseToNoon}
+      <TheSun />
     </div>
   )
 }


### PR DESCRIPTION
Issue: #380 

---

This pull request includes changes to the `DividerInFooter.tsx` file to correct the order of elements and gradients representing different times of the day. The most important changes include reversing the gradient directions and reordering the elements to reflect the correct sunrise and sunset positions.

Changes to gradients and element order:

- [`components/layout/footer/divider/DividerInFooter.tsx`](diffhunk://#diff-f065ab78308ac4693cc86a6d74767a1cca5da0b29a47dc928179b7b817ad3c76L25-R37): 
  - Reversed the gradient directions for `sunRiseToNoon` and `noonToSunSet` to correctly represent sunrise and sunset.
  - Reordered the elements in the `DividerWithGradient` component to place `TheSun` at the end, correctly reflecting the sunrise in the east and sunset in the west.