### PR TITLE
refactor(resume): 👷 bust cache for new PDF link

### DIFF
--- a/__tests__/playwright/pages/resume/resumeLink.spec.ts
+++ b/__tests__/playwright/pages/resume/resumeLink.spec.ts
@@ -37,7 +37,7 @@ test.describe('Resume page', () => {
     await checkLink(
       page,
       'call-to-action-link-resume-download',
-      'https://drive.google.com/file/d/1NBBJJaK_zsvqtNiiF388kygQ4gqi0mLD/view',
+      'https://drive.google.com/file/d/19f_qMtW2P2CPaNH_dkPdtAXRe-1pfUwL/view',
     )
   })
 })

--- a/components/shared/call-to-action/CallToActionResumeDownload.tsx
+++ b/components/shared/call-to-action/CallToActionResumeDownload.tsx
@@ -12,7 +12,7 @@ const CallToActionResumeDownload: FC = (): JSX.Element => {
       highlight="Resume in PDF"
       heading="Download My Resume"
       description="Get a PDF copy of my resume to learn more about my professional experience."
-      link={EXTERNAL_URL.resume.resumeViewPDF}
+      link={EXTERNAL_URL.resumeViewPDF}
       linkText={TEXT.downloadResume}
       dataTestId={DATA_TEST_IDS.callToAction.linkResumeDownload}
       icon="📝"

--- a/lib/utils/constants/urls/externalUrls.ts
+++ b/lib/utils/constants/urls/externalUrls.ts
@@ -1,10 +1,5 @@
-const RESUME_GOOGLE_DRIVE_URL = 'https://drive.google.com/file/d/1NBBJJaK_zsvqtNiiF388kygQ4gqi0mLD'
-
 export const EXTERNAL_URL = {
   linkedin: 'https://www.linkedin.com/in/krsiakdaniel/',
   github: 'https://github.com/krsiakdaniel/portfolio-website-krsiak-cz',
-  resume: {
-    resumeViewPDF: `${RESUME_GOOGLE_DRIVE_URL}/view`,
-    resumeEmbedPreviewPDF: `${RESUME_GOOGLE_DRIVE_URL}/preview`,
-  },
+  resumeViewPDF: 'https://drive.google.com/file/d/19f_qMtW2P2CPaNH_dkPdtAXRe-1pfUwL/view',
 }


### PR DESCRIPTION
Issue: `n/a`

---

This pull request includes updates to the resume download link across multiple files to reflect a new URL. The changes ensure consistency and correctness in the resume link used throughout the codebase.

### Updates to resume download link:

* [`__tests__/playwright/pages/resume/resumeLink.spec.ts`](diffhunk://#diff-eb65436e2ae073ba08901e819d5f619dc1ab1570532407912b25a8dcb526876cL40-R40): Updated the resume download link in the test to the new URL.
* [`components/shared/call-to-action/CallToActionResumeDownload.tsx`](diffhunk://#diff-6836da6ae40438fc16464adea64f2244106f889e1ccc3f00a31b126a9c1c0738L15-R15): Changed the reference to the resume download link to use the updated URL.
* [`lib/utils/constants/urls/externalUrls.ts`](diffhunk://#diff-7b8774f8bffbd3db35c5e87650ecfce8f84f0fdf3e14fb1646fa82f39097c214L1-R4): Removed the old URL and added the new resume download link directly to the `EXTERNAL_URL` object.