### PR TITLE
refactor(resume): 👷 new url cache busting

### DIFF
--- a/__tests__/playwright/pages/resume/resumeLink.spec.ts
+++ b/__tests__/playwright/pages/resume/resumeLink.spec.ts
@@ -37,7 +37,7 @@ test.describe('Resume page', () => {
     await checkLink(
       page,
       'call-to-action-link-resume-download',
-      'https://drive.google.com/file/d/1DojaCER-LyXm-jlEKoYZdwsJX-AG8bCr/view',
+      'https://drive.google.com/file/d/1cn3NIOQ1hJcuBBFMCyssc91ri2Tezm4w/view',
     )
   })
 })

--- a/components/pages/resume/CareerPath.tsx
+++ b/components/pages/resume/CareerPath.tsx
@@ -4,9 +4,9 @@ import ExpertiseSection from '@/components/pages/home/expertise/ExpertiseSection
 import Highlight from '@/components/shared/Highlight'
 import Paragraph from '@/components/shared/Paragraph'
 
-import { careerAutomation } from '@/lib/data/pages/resume/career-path/careerAutomation'
-import { careerFrontEnd } from '@/lib/data/pages/resume/career-path/careerFrontEnd'
-import { careerReact } from '@/lib/data/pages/resume/career-path/careerReact'
+import { careerReactDev } from '@/lib/data/pages/resume/career-path/careerReactDev'
+import { careerTesting } from '@/lib/data/pages/resume/career-path/careerTesting'
+import { careerWebDev } from '@/lib/data/pages/resume/career-path/careerWebDev'
 
 const CareerPath: FC = (): JSX.Element => {
   return (
@@ -21,9 +21,9 @@ const CareerPath: FC = (): JSX.Element => {
       </div>
 
       <div className="mt-8 flex flex-wrap gap-20">
-        <ExpertiseSection heading="⚛️ React Dev" listItems={careerReact} />
-        <ExpertiseSection heading="🖥️ Front End" listItems={careerFrontEnd} />
-        <ExpertiseSection heading="⚙️ Testing" listItems={careerAutomation} />
+        <ExpertiseSection heading="⚛️ React Dev" listItems={careerReactDev} />
+        <ExpertiseSection heading="🖥️ Web Dev" listItems={careerWebDev} />
+        <ExpertiseSection heading="⚙️ Testing" listItems={careerTesting} />
       </div>
     </>
   )

--- a/lib/data/pages/resume/career-path/careerReactDev.ts
+++ b/lib/data/pages/resume/career-path/careerReactDev.ts
@@ -1,6 +1,6 @@
 import { SkillsInfo } from '@/lib/utils/typeDefinitions/interfaces'
 
-export const careerReact: SkillsInfo[] = [
+export const careerReactDev: SkillsInfo[] = [
   { id: 0, text: '💬 Smartsupp - Dashboard', years: '3 years' },
   { id: 1, text: '🏦 Komerční banka - Website', years: '10 months' },
   { id: 2, text: '☔ Kooperativa - App', years: '8 months' },

--- a/lib/data/pages/resume/career-path/careerTesting.ts
+++ b/lib/data/pages/resume/career-path/careerTesting.ts
@@ -1,6 +1,6 @@
 import { SkillsInfo } from '@/lib/utils/typeDefinitions/interfaces'
 
-export const careerAutomation: SkillsInfo[] = [
+export const careerTesting: SkillsInfo[] = [
   { id: 0, text: '🤖 QA Automation - Team Lead', years: '1 year' },
   { id: 1, text: '🇨🇿 Localization - Manager', years: '2 years' },
   { id: 2, text: '🈺 Localization - Tester', years: '3 years' },

--- a/lib/data/pages/resume/career-path/careerWebDev.ts
+++ b/lib/data/pages/resume/career-path/careerWebDev.ts
@@ -1,6 +1,6 @@
 import { SkillsInfo } from '@/lib/utils/typeDefinitions/interfaces'
 
-export const careerFrontEnd: SkillsInfo[] = [
+export const careerWebDev: SkillsInfo[] = [
   { id: 0, text: '💻 Smartsupp - Website', years: '1 year' },
   { id: 1, text: '💼 Freelance - Websites', years: '5 years' },
   { id: 2, text: '👨🏻‍💻 Freelance - Web Coder', years: '1 year' },

--- a/lib/utils/constants/urls/externalUrls.ts
+++ b/lib/utils/constants/urls/externalUrls.ts
@@ -1,5 +1,5 @@
 export const EXTERNAL_URL = {
   linkedin: 'https://www.linkedin.com/in/krsiakdaniel/',
   github: 'https://github.com/krsiakdaniel/portfolio-website-krsiak-cz',
-  resumeViewPDF: 'https://drive.google.com/file/d/1DojaCER-LyXm-jlEKoYZdwsJX-AG8bCr/view',
+  resumeViewPDF: 'https://drive.google.com/file/d/1cn3NIOQ1hJcuBBFMCyssc91ri2Tezm4w/view',
 }


### PR DESCRIPTION
Issue: `n/a`

---

This pull request includes updates to the resume page and related components, focusing on changing URLs and renaming variables for clarity. The most important changes include updating the resume download link, renaming career path variables, and modifying the expertise sections.

### URL Updates:
* Updated the resume download link in `resumeLink.spec.ts` to the new Google Drive URL.
* Updated the `resumeViewPDF` URL in `externalUrls.ts` to the new Google Drive URL.

### Variable Renaming:
* Renamed `careerReact` to `careerReactDev` in `careerReactDev.ts` and updated the imports accordingly in `CareerPath.tsx`. [[1]](diffhunk://#diff-f38f34e1f174b109903860bceca867171789078d2f71cc042c795d9a97f3c181L3-R3) [[2]](diffhunk://#diff-5d7165804ff3f0f8c8d04cd872b8afe16cbcebb75bbb5f8d8ef1f915515107f0L7-R9)
* Renamed `careerAutomation` to `careerTesting` in `careerTesting.ts` and updated the imports accordingly in `CareerPath.tsx`. [[1]](diffhunk://#diff-8e4aa91bf5dd516d67057b2bfd79a4d3709495e76bd429e93fa825c2d95b6397L3-R3) [[2]](diffhunk://#diff-5d7165804ff3f0f8c8d04cd872b8afe16cbcebb75bbb5f8d8ef1f915515107f0L7-R9)
* Renamed `careerFrontEnd` to `careerWebDev` in `careerWebDev.ts` and updated the imports accordingly in `CareerPath.tsx`. [[1]](diffhunk://#diff-e439e8e7401cef536d0e8a5e6db8633acd5caa8bae29bf828f69cc4569b97d15L3-R3) [[2]](diffhunk://#diff-5d7165804ff3f0f8c8d04cd872b8afe16cbcebb75bbb5f8d8ef1f915515107f0L7-R9)

### Expertise Section Updates:
* Updated the `ExpertiseSection` headings and list items in `CareerPath.tsx` to reflect the renamed variables.