### PR TITLE
refactor(heading): 👷 text in hero section

### DIFF
--- a/__tests__/playwright/lib/utils/constants/ids/dataTestIds.ts
+++ b/__tests__/playwright/lib/utils/constants/ids/dataTestIds.ts
@@ -72,6 +72,7 @@ const MENU = {
 
 const HERO = {
   heading: 'hero-heading',
+  headingSmall: 'hero-heading-small',
   paragraph: 'hero-paragraph',
 }
 

--- a/__tests__/playwright/pages/home/heroTexts.spec.ts
+++ b/__tests__/playwright/pages/home/heroTexts.spec.ts
@@ -1,7 +1,5 @@
 import { Browser, BrowserContext, expect, Page, test } from '@playwright/test'
 
-import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/dataTestIds'
-
 import { getDataTestId } from '@/__tests__/playwright/lib/utils/helpers/getDataTestId'
 import { setupBrowser, setupPage, teardownContext } from '@/__tests__/playwright/lib/utils/helpers/setup'
 
@@ -36,14 +34,19 @@ test.afterEach(async () => {
 test.describe('Hero - Heading and texts', () => {
   // Test to check if the h1 heading is rendered correctly
   test('should render the h1 heading correctly', async () => {
-    const h1Text = await page.textContent(getDataTestId(DATA_TEST_IDS.hero.heading))
+    const h1Text = await page.textContent(getDataTestId('hero-heading'))
     expect(h1Text).toContain('Daniel Kršiak')
-    expect(h1Text).toContain('React Developer')
+  })
+
+  // Test to check if the small text inside h1 heading is rendered correctly
+  test('should render small text inside h1 heading correctly', async () => {
+    const h1Text = await page.textContent(getDataTestId('hero-heading-small'))
+    expect(h1Text).toContain('Developer: React &\u00A0TypeScript')
   })
 
   // Test to check if the paragraphs are rendered correctly
   test('should render the paragraphs correctly', async () => {
-    const paragraph1Text = await page.textContent(getDataTestId(DATA_TEST_IDS.hero.paragraph))
+    const paragraph1Text = await page.textContent(getDataTestId('hero-paragraph'))
     expect(paragraph1Text).toContain('Hi 👋 I am from Czech\u00A0Republic 🇨🇿')
   })
 })

--- a/components/pages/home/hero/HeroHeading.tsx
+++ b/components/pages/home/hero/HeroHeading.tsx
@@ -4,12 +4,18 @@ import Heading1 from '@/components/shared/Heading1'
 
 import { TEXT } from '@/localization/english'
 
+import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/dataTestIds'
+
 const HeroHeading: FC = (): JSX.Element => {
   return (
-    <Heading1 dataTestId="hero-heading" textColor="text-neutral-900" customCss="flex flex-col text-center">
+    <Heading1
+      dataTestId={DATA_TEST_IDS.hero.heading}
+      textColor="text-neutral-900"
+      customCss="flex flex-col text-center"
+    >
       <span>{TEXT.nameDanielKrsiak}</span>
-      <small className="mt-2">
-        <span className="text-violet-600">{TEXT.reactDeveloperTypeScript}</span>
+      <small className="mt-2 text-violet-600" data-testid={DATA_TEST_IDS.hero.headingSmall}>
+        {TEXT.reactDeveloperTypeScript}
       </small>
     </Heading1>
   )

--- a/components/pages/home/hero/HeroHeading.tsx
+++ b/components/pages/home/hero/HeroHeading.tsx
@@ -8,7 +8,9 @@ const HeroHeading: FC = (): JSX.Element => {
   return (
     <Heading1 dataTestId="hero-heading" textColor="text-neutral-900" customCss="flex flex-col text-center">
       <span>{TEXT.nameDanielKrsiak}</span>
-      <span className="mt-2 text-violet-600">{TEXT.reactDeveloper}</span>
+      <small className="mt-2">
+        <span className="text-violet-600">{TEXT.reactDeveloperTypeScript}</span>
+      </small>
     </Heading1>
   )
 }

--- a/localization/english.ts
+++ b/localization/english.ts
@@ -1,6 +1,7 @@
 export const COMMON_VALUES = {
   nameDanielKrsiak: 'Daniel Kršiak',
   reactDeveloper: 'React Developer',
+  reactDeveloperTypeScript: 'Developer: React &\u00A0TypeScript',
   javaScript: 'JavaScript',
   javaScriptShort: 'JS',
   typeScript: 'TypeScript',
@@ -511,6 +512,7 @@ export const IMAGE_ALT = {
 }
 
 export const TEXT = {
+  ...COMMON_VALUES,
   ...PROJECT_INFORMATION,
   ...MY_WORK,
   ...SOCIAL_LINKS,


### PR DESCRIPTION
Issue: `n/a`

---

This pull request includes changes to the `HeroHeading` component and updates to the localization file to reflect the addition of TypeScript to the developer description.

Changes to `HeroHeading` component:

* [`components/pages/home/hero/HeroHeading.tsx`](diffhunk://#diff-b80f63f02d85c89e1d13cd1ac8eed0ef2aee42fa352e0afed7a87db36f6798b2L11-R13): Updated the developer description to include TypeScript and adjusted the HTML structure to use a `small` tag for better semantic meaning.

Updates to localization file:

* [`localization/english.ts`](diffhunk://#diff-56f60b3fd203762cbec540ddf7d4e9c68ead8992ead4bacec6f9a44913368ef7R4): Added a new entry for `reactDeveloperTypeScript` to include TypeScript in the developer description.
* [`localization/english.ts`](diffhunk://#diff-56f60b3fd203762cbec540ddf7d4e9c68ead8992ead4bacec6f9a44913368ef7R515): Included `COMMON_VALUES` in the `TEXT` export to ensure all common values are accessible.