### PR TITLE
test(menu): ✅ links - GitHub and LinkedIn

### DIFF
--- a/__tests__/playwright/layout/header/menu/desktop/socialLinks.spec.ts
+++ b/__tests__/playwright/layout/header/menu/desktop/socialLinks.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/test'
+
+import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/dataTestIds'
+import { getDataTestId } from '@/__tests__/playwright/lib/utils/helpers/getDataTestId'
+
+// Define data test IDs for GitHub and LinkedIn links
+const dataTestIdGitHub = `desktop-${DATA_TEST_IDS.menu.socialLinks.gitHubRepo}`
+const dataTestIdLinkedIn = `desktop-${DATA_TEST_IDS.menu.socialLinks.linkedInProfile}`
+
+test.describe('Header - Desktop Menu - Social Links', () => {
+  test('should render GitHub link correctly', async ({ page }) => {
+    // Navigate to the home page
+    await test.step('Go to home page', async () => {
+      await page.goto('/')
+    })
+
+    await test.step('GitHub - link is visible and has correct URL', async () => {
+      // Check if the GitHub link is visible
+      const gitHubLink = await page.isVisible(getDataTestId(dataTestIdGitHub))
+      expect(gitHubLink).toBe(true)
+
+      // Check if the GitHub link has the correct href attribute
+      const gitHubHref = await page.getAttribute(getDataTestId(dataTestIdGitHub), 'href')
+      expect(gitHubHref).toBe('https://github.com/krsiakdaniel/portfolio-website-krsiak-cz')
+    })
+  })
+
+  test('should render LinkedIn link correctly', async ({ page }) => {
+    // Navigate to the home page
+    await test.step('Go to home page', async () => {
+      await page.goto('/')
+    })
+
+    await test.step('LinkedIn - link is visible and has correct URL', async () => {
+      // Check if the LinkedIn link is visible
+      const linkedInLink = await page.isVisible(getDataTestId(dataTestIdLinkedIn))
+      expect(linkedInLink).toBe(true)
+
+      // Check if the LinkedIn link has the correct href attribute
+      const linkedInHref = await page.getAttribute(getDataTestId(dataTestIdLinkedIn), 'href')
+      expect(linkedInHref).toBe('https://www.linkedin.com/in/krsiakdaniel/')
+    })
+  })
+})

--- a/__tests__/playwright/layout/header/menu/mobile/menuMobileSocialLinks.spec.ts
+++ b/__tests__/playwright/layout/header/menu/mobile/menuMobileSocialLinks.spec.ts
@@ -1,0 +1,60 @@
+import { Browser, BrowserContext, chromium, expect, Page, test } from '@playwright/test'
+
+import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/dataTestIds'
+
+import { getDataTestId } from '@/__tests__/playwright/lib/utils/helpers/getDataTestId'
+
+// Define data test IDs for GitHub and LinkedIn links
+const dataTestIdGitHub = `mobile-${DATA_TEST_IDS.menu.socialLinks.gitHubRepo}`
+const dataTestIdLinkedIn = `mobile-${DATA_TEST_IDS.menu.socialLinks.linkedInProfile}`
+
+// Define the variables for the browser, context, and page
+let browser: Browser
+let context: BrowserContext
+let page: Page
+
+test.beforeAll(async () => {
+  browser = await chromium.launch()
+  context = await browser.newContext({ viewport: { width: 500, height: 600 } })
+  page = await context.newPage()
+})
+
+test.beforeEach(async () => {
+  // Set the viewport size to a smaller size to simulate a mobile device
+  await page.setViewportSize({ width: 500, height: 600 })
+
+  // Go to the home page
+  await test.step('Go to home page', async () => {
+    await page.goto('/')
+  })
+})
+
+test.afterAll(async () => {
+  await browser.close()
+})
+
+test.describe('Header - Mobile Menu - Social Links', () => {
+  test('should render GitHub link correctly', async ({ page }) => {
+    await test.step('GitHub - link is visible and has correct URL', async () => {
+      // Check if the GitHub link is visible
+      const gitHubLink = await page.isVisible(getDataTestId(dataTestIdGitHub))
+      expect(gitHubLink).toBe(true)
+
+      // Check if the GitHub link has the correct href attribute
+      const gitHubHref = await page.getAttribute(getDataTestId(dataTestIdGitHub), 'href')
+      expect(gitHubHref).toBe('https://github.com/krsiakdaniel/portfolio-website-krsiak-cz')
+    })
+  })
+
+  test('should render LinkedIn link correctly', async ({ page }) => {
+    await test.step('LinkedIn - link is visible and has correct URL', async () => {
+      // Check if the LinkedIn link is visible
+      const linkedInLink = await page.isVisible(getDataTestId(dataTestIdLinkedIn))
+      expect(linkedInLink).toBe(true)
+
+      // Check if the LinkedIn link has the correct href attribute
+      const linkedInHref = await page.getAttribute(getDataTestId(dataTestIdLinkedIn), 'href')
+      expect(linkedInHref).toBe('https://www.linkedin.com/in/krsiakdaniel/')
+    })
+  })
+})

--- a/components/layout/header/menu/MenuSocialLinks.tsx
+++ b/components/layout/header/menu/MenuSocialLinks.tsx
@@ -17,12 +17,20 @@ import iconLinkedIn from '@/public/icons/svg/social/linkedin.svg'
 const MenuSocialLinks: FC<MenuSocialLinksProps> = ({ type }): JSX.Element => {
   const isMobile = type === DeviceTypeEnum.Mobile
 
+  const dataTestIdGitHub = isMobile
+    ? `mobile-${DATA_TEST_IDS.menu.socialLinks.gitHubRepo}`
+    : `desktop-${DATA_TEST_IDS.menu.socialLinks.gitHubRepo}`
+
+  const dataTestIdLinkedIn = isMobile
+    ? `mobile-${DATA_TEST_IDS.menu.socialLinks.linkedInProfile}`
+    : `desktop-${DATA_TEST_IDS.menu.socialLinks.linkedInProfile}`
+
   return (
     <div className={`flex items-center space-x-2 ${isMobile ? 'ml-2' : 'ml-6'}`}>
       <SocialLinkIcon
         type={type}
         href={EXTERNAL_URL.gitHub}
-        dataTestId={DATA_TEST_IDS.menu.socialLinks.gitHubRepo}
+        dataTestId={dataTestIdGitHub}
         title={`${TEXT.gitHub} - ${TEXT.opensInNewTab}`}
         ariaLabel={TEXT.gitHub}
         imgSrc={iconGitHub}
@@ -32,7 +40,7 @@ const MenuSocialLinks: FC<MenuSocialLinksProps> = ({ type }): JSX.Element => {
       <SocialLinkIcon
         type={type}
         href={EXTERNAL_URL.linkedIn}
-        dataTestId={DATA_TEST_IDS.menu.socialLinks.linkedInProfile}
+        dataTestId={dataTestIdLinkedIn}
         title={`${TEXT.linkedIn} - ${TEXT.opensInNewTab}`}
         ariaLabel={TEXT.linkedIn}
         imgSrc={iconLinkedIn}

--- a/lib/utils/constants/urls/externalUrls.ts
+++ b/lib/utils/constants/urls/externalUrls.ts
@@ -1,5 +1,5 @@
 export const EXTERNAL_URL = {
-  linkedIn: 'https://www.linkedin.com/in/krsiakdaniel/',
   gitHub: 'https://github.com/krsiakdaniel/portfolio-website-krsiak-cz',
+  linkedIn: 'https://www.linkedin.com/in/krsiakdaniel/',
   resumeViewPDF: 'https://drive.google.com/file/d/1iq41KRaiwTjyCxYrGXEFcbsq5rKbQkBm/view',
 }


### PR DESCRIPTION
Issue: #426 

---

This pull request introduces tests for social links in both desktop and mobile menus, refactors the `MenuSocialLinks` component to use dynamic data test IDs, and makes minor adjustments to the external URLs constants.

### Testing for social links:

* [`__tests__/playwright/layout/header/menu/desktop/socialLinks.spec.ts`](diffhunk://#diff-77c2216a099c514a301e8903d4518c3d875df1159738ad7348bceeb3fdb41aa0R1-R44): Added tests to verify that the GitHub and LinkedIn links are visible and have the correct URLs in the desktop menu.
* [`__tests__/playwright/layout/header/menu/mobile/menuMobileSocialLinks.spec.ts`](diffhunk://#diff-2bd467dddfd4e4d32ed6444a06af93c3294b90bc89bc31610b95a2e19b7b5129R1-R60): Added tests to verify that the GitHub and LinkedIn links are visible and have the correct URLs in the mobile menu.

### Refactoring `MenuSocialLinks` component:

* [`components/layout/header/menu/MenuSocialLinks.tsx`](diffhunk://#diff-728f4230dd702a1255aa20af28f6fbbffbcac2b8f70327b51ce8827d75a38f20R20-R33): Updated the component to use dynamic data test IDs based on the device type for GitHub and LinkedIn links. [[1]](diffhunk://#diff-728f4230dd702a1255aa20af28f6fbbffbcac2b8f70327b51ce8827d75a38f20R20-R33) [[2]](diffhunk://#diff-728f4230dd702a1255aa20af28f6fbbffbcac2b8f70327b51ce8827d75a38f20L35-R43)

### Minor adjustments:

* [`lib/utils/constants/urls/externalUrls.ts`](diffhunk://#diff-7b8774f8bffbd3db35c5e87650ecfce8f84f0fdf3e14fb1646fa82f39097c214L2-R3): Reordered the `linkedIn` URL to maintain alphabetical order.