### PR TITLE
fix(link): 🐛 button width

### DIFF
--- a/components/pages/projects/overview-page/ProjectSummaryCard.tsx
+++ b/components/pages/projects/overview-page/ProjectSummaryCard.tsx
@@ -38,13 +38,7 @@ const ProjectSummaryCard: FC<ProjectSummaryCardProps> = ({
               personalProjectNote={personalProjectNote}
             />
             <ProjectSkillsIcons skillsIcons={skillsIcons} />
-            <LinkButton
-              href={linkProjectPage}
-              linkText={linkText}
-              isLinkExternal={false}
-              dataTestId={dataTestId}
-              maxWidth="176px"
-            />
+            <LinkButton href={linkProjectPage} linkText={linkText} isLinkExternal={false} dataTestId={dataTestId} />
           </div>
         </div>
       </div>

--- a/components/shared/LinkButton.tsx
+++ b/components/shared/LinkButton.tsx
@@ -7,13 +7,7 @@ import { TEXT } from '@/localization/english'
 
 import { ArrowDirectionEnum } from '@/lib/utils/typeDefinitions/enums'
 
-const LinkButton: FC<LinkButtonProps> = ({
-  href,
-  linkText,
-  isLinkExternal = false,
-  dataTestId,
-  maxWidth = '176px',
-}) => {
+const LinkButton: FC<LinkButtonProps> = ({ href, linkText, isLinkExternal = false, dataTestId }) => {
   const hoverAndFocusCSS =
     'hover:bg-violet-800 focus:bg-violet-800 focus:outline-none focus:ring-4 focus:ring-violet-400'
 
@@ -24,7 +18,7 @@ const LinkButton: FC<LinkButtonProps> = ({
         target={isLinkExternal ? '_blank' : '_self'}
         rel={isLinkExternal ? 'noopener noreferrer' : 'next'}
         title={isLinkExternal ? `${linkText} - ${TEXT.opensInNewTab}` : linkText}
-        className={`flex select-none items-center justify-center space-x-2 rounded-lg bg-violet-600 px-5 py-2.5 text-center text-sm font-medium text-white max-w-[${maxWidth}] ${hoverAndFocusCSS}`}
+        className={`inline-flex w-[248px] select-none items-center justify-center space-x-2 rounded-lg bg-violet-600 px-5 py-2.5 text-center text-sm font-medium text-white ${hoverAndFocusCSS}`}
         data-testid={dataTestId}
       >
         <span>{linkText}</span>

--- a/components/shared/call-to-action/CallToAction.tsx
+++ b/components/shared/call-to-action/CallToAction.tsx
@@ -29,13 +29,7 @@ const CallToAction: FC<CallToActionProps> = ({
             textMobileAndDesktop={textMobileAndDesktop}
             textDesktop={textDesktop}
           />
-          <LinkButton
-            href={link}
-            linkText={linkText}
-            isLinkExternal={isLinkExternal}
-            dataTestId={dataTestId}
-            maxWidth="300px"
-          />
+          <LinkButton href={link} linkText={linkText} isLinkExternal={isLinkExternal} dataTestId={dataTestId} />
         </div>
 
         <div className="hidden items-center justify-center md:flex md:w-1/3">

--- a/lib/utils/typeDefinitions/props/shared/link-button.ts
+++ b/lib/utils/typeDefinitions/props/shared/link-button.ts
@@ -4,5 +4,4 @@ type LinkButtonProps = {
   linkText: string
   isLinkExternal?: boolean
   dataTestId?: string
-  maxWidth?: string
 }

--- a/localization/english.ts
+++ b/localization/english.ts
@@ -39,7 +39,7 @@ export const DIVIDER_WITH_TEXT = {
 
 export const SOCIAL_LINKS = {
   linkedIn: 'LinkedIn',
-  myLinkedIn: 'My LinkedIn',
+  myLinkedIn: 'LinkedIn: Krsiak Daniel',
   gitHub: 'GitHub',
   gitHubCode: 'GitHub Code',
   resumePDF: 'Resume PDF',


### PR DESCRIPTION
- **Issue**: `n/a`

---

- 🐛 **Bug**: In deploy preview the button width from flex was `w-full` = `100%`.
- ✅ **Fixed**: Set specific width of `248px`.

---

This pull request includes changes to the `LinkButton` component and related files to simplify its usage and remove the `maxWidth` property. Additionally, there are minor updates to localization text.

### Simplification of `LinkButton` component:

* [`components/pages/projects/overview-page/ProjectSummaryCard.tsx`](diffhunk://#diff-c6d27ce52f5921aa00d1bebe46c1c15d4e43daa176b4c77f52997b11785f7682L41-R41): Updated `LinkButton` usage to remove the `maxWidth` property.
* [`components/shared/LinkButton.tsx`](diffhunk://#diff-0784b5e306fc2e893c98286c0a4d59696b76b514a99c139882566300cdd70a53L10-R10): Removed the `maxWidth` property from the `LinkButton` component and updated its class to use a fixed width. [[1]](diffhunk://#diff-0784b5e306fc2e893c98286c0a4d59696b76b514a99c139882566300cdd70a53L10-R10) [[2]](diffhunk://#diff-0784b5e306fc2e893c98286c0a4d59696b76b514a99c139882566300cdd70a53L27-R21)
* [`components/shared/call-to-action/CallToAction.tsx`](diffhunk://#diff-5632d2dd20b34f76aba188669a2398061af66987f7c0d6fc9216354b390d2687L32-R32): Updated `LinkButton` usage to remove the `maxWidth` property.
* [`lib/utils/typeDefinitions/props/shared/link-button.ts`](diffhunk://#diff-7a61689fc5d586680144364dce6fdec1260d8bba4142e36ec725f9e55a74a831L7): Removed the `maxWidth` property from the `LinkButtonProps` type definition.

### Localization updates:

* [`localization/english.ts`](diffhunk://#diff-56f60b3fd203762cbec540ddf7d4e9c68ead8992ead4bacec6f9a44913368ef7L42-R42): Updated the `myLinkedIn` text in the `SOCIAL_LINKS` object.