### PR TITLE
refactor(layout): 👷 grid and texts

### DIFF
--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -30,10 +30,10 @@ const Resume: FC = (): JSX.Element => {
       <div className="mt-10">
         <div>
           <Heading1>
-            <span role="img" className="select-none">
+            <span role="img" className="mr-4 select-none">
               {ICON_EMOJI.memo}
             </span>
-            <span className="ml-4">{TEXT.resume}</span>
+            <span>{TEXT.resume}</span>
           </Heading1>
           <ResumeIntroduction />
         </div>

--- a/app/status-page/page.tsx
+++ b/app/status-page/page.tsx
@@ -31,10 +31,10 @@ const StatusPage: FC = (): JSX.Element => {
       <div className="mt-10">
         <div>
           <Heading1>
-            <span role="img" className="select-none">
+            <span role="img" className="mr-4 select-none">
               {ICON_EMOJI.verticalTrafficLight}
             </span>
-            <span className="ml-4">{TEXT.statusPage}</span>
+            <span>{TEXT.statusPage}</span>
           </Heading1>
           <StatusPageIntroduction />
         </div>

--- a/app/testimonials/page.tsx
+++ b/app/testimonials/page.tsx
@@ -34,10 +34,10 @@ const Testimonials: FC = (): JSX.Element => {
       <div className="mt-10">
         <div>
           <Heading1>
-            <span role="img" className="select-none">
+            <span role="img" className="mr-4 select-none">
               {ICON_EMOJI.speechBalloon}
             </span>
-            <span className="ml-4">{TEXT.testimonials}</span>
+            <span>{TEXT.testimonials}</span>
           </Heading1>
           <TestimonialsIntroduction />
         </div>

--- a/app/work-experience/smartsupp-dashboard/page.tsx
+++ b/app/work-experience/smartsupp-dashboard/page.tsx
@@ -27,7 +27,7 @@ const ProjectWorkSmartsuppDashboard: FC = (): JSX.Element => {
       breadCrumbs={getBreadcrumbsWork(
         PAGES_URL.work.smartsupp.dashboard,
         ICON_EMOJI.speechBalloon,
-        TEXT.smartsuppDashboard,
+        TEXT.smartsuppChatDashboard,
       )}
       pageID={PROJECT_ID.work.smartsupp.dashboard}
       goBackLink={GoBackLinkEnum.Work}

--- a/components/layout/projects/ProjectsOverviewLayout.tsx
+++ b/components/layout/projects/ProjectsOverviewLayout.tsx
@@ -14,10 +14,10 @@ const ProjectsOverviewLayout: FC<ProjectsOverviewLayoutProps> = ({
     <>
       <div className="mt-10 flex flex-col">
         <Heading1>
-          <span role="img" className="select-none">
+          <span role="img" className="mr-4 select-none">
             {icon}
           </span>
-          <span className="ml-4">{heading}</span>
+          <span>{heading}</span>
         </Heading1>
         <div>{description}</div>
       </div>

--- a/components/layout/projects/project-page/HeaderSection.tsx
+++ b/components/layout/projects/project-page/HeaderSection.tsx
@@ -18,7 +18,7 @@ const HeaderSection: FC<HeaderSectionProps> = ({
   return (
     <div className="mt-10">
       <Heading1 textColor="text-neutral-900">
-        <span className="select-none">{icon}</span> <span className="ml-1">{title}</span>
+        <span className="select-none">{icon}</span> <span className="ml-0">{title}</span>
       </Heading1>
 
       <Heading2 customCss="mt-2">

--- a/components/pages/home/Companies.tsx
+++ b/components/pages/home/Companies.tsx
@@ -7,7 +7,6 @@ import ImageComponent from '@/components/shared/ImageComponent'
 import { DIVIDER_WITH_TEXT, IMAGE_ALT, TEXT } from '@/localization/english'
 
 import groupon from '@/public/images/svg/logo/groupon.svg'
-import ibm from '@/public/images/svg/logo/ibm.svg'
 import komercniBanka from '@/public/images/svg/logo/komercni-banka.svg'
 import kooperativa from '@/public/images/svg/logo/kooperativa.svg'
 import microsoft from '@/public/images/svg/logo/microsoft.svg'
@@ -17,14 +16,13 @@ import smartsupp from '@/public/images/svg/logo/smartsupp.svg'
 const WIDTH_MICROSOFT = 256
 const WIDTH_SMARTSUPP = 256
 const WIDTH_KOOPERATIVA = 256
-const WIDTH_IBM = 130
 const WIDTH_RWS_MORAVIA = 200
 const WIDTH_KOMERCNI_BANKA = 130
-const WIDTH_GROUPON = 130
+const WIDTH_GROUPON = 200
 
 const Companies: FC = (): JSX.Element => {
-  const logosWrapperCss = 'flex flex-col items-center justify-center lg:mt-16 lg:flex-row lg:gap-16'
-  const imageCss = 'mt-16 lg:mt-0'
+  const logosGrid = 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-16 mt-16 justify-items-center'
+  const imgWrapper = 'flex items-center justify-center'
 
   return (
     <section>
@@ -34,56 +32,31 @@ const Companies: FC = (): JSX.Element => {
           <Heading2>{TEXT.workedForCompanies}</Heading2>
         </div>
 
-        <div className={logosWrapperCss}>
-          <ImageComponent
-            src={microsoft}
-            width={WIDTH_MICROSOFT}
-            alt={IMAGE_ALT.microsoft}
-            loading="lazy"
-            customCss={imageCss}
-          />
-          <ImageComponent
-            src={smartsupp}
-            width={WIDTH_SMARTSUPP}
-            alt={IMAGE_ALT.smartsupp}
-            loading="lazy"
-            customCss={imageCss}
-          />
-          <ImageComponent
-            src={kooperativa}
-            width={WIDTH_KOOPERATIVA}
-            alt={IMAGE_ALT.kooperativa}
-            loading="lazy"
-            customCss={imageCss}
-          />
-        </div>
-        <div className={logosWrapperCss}>
-          <ImageComponent src={ibm} width={WIDTH_IBM} alt={IMAGE_ALT.ibm} loading="lazy" customCss={imageCss} />
-          <ImageComponent
-            src={rwsMoravia}
-            width={WIDTH_RWS_MORAVIA}
-            alt={IMAGE_ALT.rwsMoravia}
-            loading="lazy"
-            customCss={imageCss}
-          />
-        </div>
-        <div className={logosWrapperCss}>
-          <ImageComponent
-            src={komercniBanka}
-            width={WIDTH_KOMERCNI_BANKA}
-            alt={IMAGE_ALT.komercniBanka}
-            loading="lazy"
-            customCss={imageCss}
-          />
-        </div>
-        <div className={logosWrapperCss}>
-          <ImageComponent
-            src={groupon}
-            width={WIDTH_GROUPON}
-            alt={IMAGE_ALT.komercniBanka}
-            loading="lazy"
-            customCss={imageCss}
-          />
+        <div className={logosGrid}>
+          <div className={imgWrapper}>
+            <ImageComponent src={kooperativa} width={WIDTH_KOOPERATIVA} alt={IMAGE_ALT.kooperativa} loading="lazy" />
+          </div>
+          <div className={imgWrapper}>
+            <ImageComponent src={smartsupp} width={WIDTH_SMARTSUPP} alt={IMAGE_ALT.smartsupp} loading="lazy" />
+          </div>
+          <div className={imgWrapper}>
+            <ImageComponent src={microsoft} width={WIDTH_MICROSOFT} alt={IMAGE_ALT.microsoft} loading="lazy" />
+          </div>
+
+          <div className={imgWrapper}>
+            <ImageComponent src={rwsMoravia} width={WIDTH_RWS_MORAVIA} alt={IMAGE_ALT.rwsMoravia} loading="lazy" />
+          </div>
+          <div className={imgWrapper}>
+            <ImageComponent
+              src={komercniBanka}
+              width={WIDTH_KOMERCNI_BANKA}
+              alt={IMAGE_ALT.komercniBanka}
+              loading="lazy"
+            />
+          </div>
+          <div className={imgWrapper}>
+            <ImageComponent src={groupon} width={WIDTH_GROUPON} alt={IMAGE_ALT.groupon} loading="lazy" />
+          </div>
         </div>
       </div>
     </section>

--- a/components/pages/home/expertise/MyExpertise.tsx
+++ b/components/pages/home/expertise/MyExpertise.tsx
@@ -14,10 +14,9 @@ const MyExpertise: FC = (): JSX.Element => {
     <div className="mt-20">
       <DividerWithText text={DIVIDER_WITH_TEXT.myExpertise} />
 
-      {/* TODO: This is layout needs to be refactored and shared 2x */}
       <div className="mt-4 w-full">
-        <div className="flex w-full flex-col gap-6 lg:flex-row">
-          <div className="flex w-full flex-col gap-6 md:flex-row lg:w-2/3">
+        <div className="grid w-full gap-6 lg:grid-cols-3">
+          <div className="grid w-full gap-6 md:grid-cols-2 lg:col-span-2">
             <ExpertiseSection
               icon={ICON_EMOJI.star}
               heading={TEXT.skillsForCompany}
@@ -29,7 +28,7 @@ const MyExpertise: FC = (): JSX.Element => {
               listItems={committedMindsetItems}
             />
           </div>
-          <div className="flex w-full lg:w-1/3">
+          <div className="w-full">
             <ExpertiseSection
               icon={ICON_EMOJI.artistPalette}
               heading={TEXT.problemSolving}

--- a/components/pages/home/skills/Skills.tsx
+++ b/components/pages/home/skills/Skills.tsx
@@ -19,22 +19,18 @@ const Skills: FC = (): JSX.Element => {
   return (
     <div id={ID.skills} className="mt-20">
       <DividerWithText text={DIVIDER_WITH_TEXT.skills} />
-      <div className="mt-4 flex flex-col justify-center space-y-2 lg:flex-row lg:space-x-4 lg:space-y-0">
-        <div className="flex flex-col justify-center space-y-2 md:flex-row md:space-x-4 md:space-y-0">
+      <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <div className="flex flex-col justify-center space-y-2 md:flex-row md:space-x-4 md:space-y-0 lg:justify-end">
           <SkillsIconGroup icons={iconsWebDevelopment} />
           <SkillsIconGroup icons={iconsWebDevelopmentWithQA} />
         </div>
-        <div className="flex flex-col justify-center space-y-2 md:flex-row md:space-x-4 md:space-y-0">
+        <div className="flex flex-col justify-center space-y-2 md:flex-row md:space-x-4 md:space-y-0 lg:justify-start">
           <SkillsIconGroup icons={iconsWebDesign} />
           <SkillsIconGroup icons={iconsDesignTools} />
         </div>
       </div>
       <div className="mt-4 flex flex-col items-center">
-        <Paragraph
-          textColor="text-neutral-500"
-          size="text-md"
-          customCss="sm:w-[300px] text-center italic md:w-[600px] lg:w-full"
-        >
+        <Paragraph textColor="text-neutral-500" size="text-md" customCss="w-[270px] text-center italic md:w-[520px]">
           {TEXT.skillsIconsNames}
         </Paragraph>
       </div>

--- a/components/pages/projects/overview-page/ProjectSummaryCard.tsx
+++ b/components/pages/projects/overview-page/ProjectSummaryCard.tsx
@@ -25,24 +25,21 @@ const ProjectSummaryCard: FC<ProjectSummaryCardProps> = ({
 }): JSX.Element => {
   return (
     <section>
-      <div className="flex flex-col lg:flex-row lg:space-x-10">
-        <div className={`grid grid-cols-1 items-start gap-8 lg:mx-auto lg:grid lg:grid-cols-2 ${className}`}>
-          <ProjectImage isFeatured={isFeatured} image={image} title={title} />
-
-          <div>
-            <ProjectDetails
-              title={title}
-              icon={icon}
-              company={company}
-              role={role}
-              description={description}
-              customers={customers}
-              personalProjectNote={personalProjectNote}
-            />
-            <ProjectSkillsIcons skillsIcons={skillsIcons} />
-            <div className="mt-8 flex max-w-[248px]">
-              <LinkButton href={linkProjectPage} linkText={linkText} isLinkExternal={false} dataTestId={dataTestId} />
-            </div>
+      <div className={`grid grid-cols-1 gap-8 lg:grid-cols-2 ${className}`}>
+        <ProjectImage isFeatured={isFeatured} image={image} title={title} />
+        <div>
+          <ProjectDetails
+            title={title}
+            icon={icon}
+            company={company}
+            role={role}
+            description={description}
+            customers={customers}
+            personalProjectNote={personalProjectNote}
+          />
+          <ProjectSkillsIcons skillsIcons={skillsIcons} />
+          <div className="mt-8 flex max-w-[248px]">
+            <LinkButton href={linkProjectPage} linkText={linkText} isLinkExternal={false} dataTestId={dataTestId} />
           </div>
         </div>
       </div>

--- a/components/pages/resume/CareerPath.tsx
+++ b/components/pages/resume/CareerPath.tsx
@@ -5,7 +5,7 @@ import CareerPathJobStep from '@/components/pages/resume/CareerPathJobStep'
 import HeadingSection from '@/components/shared/HeadingSection'
 import Paragraph from '@/components/shared/Paragraph'
 
-import { ICON_EMOJI } from '@/localization/english'
+import { ICON_EMOJI, TEXT } from '@/localization/english'
 
 import { careerPathSteps } from '@/lib/data/pages/resume/career-path/careerPathSteps'
 import { careerReactDev } from '@/lib/data/pages/resume/career-path/careerReactDev'
@@ -17,21 +17,22 @@ const CareerPath: FC = (): JSX.Element => {
     <>
       <HeadingSection text="My Career Path" />
 
-      <Paragraph size="text-sm">
-        <span className="font-bold">My journey:</span>{' '}
+      <Paragraph size="text-sm" customCss="hidden lg:block">
+        <span className="font-bold">{TEXT.myJourney}</span>{' '}
         {(careerPathSteps ?? []).map((step, index) => (
           <CareerPathJobStep key={step.id} step={step} index={index} />
         ))}
       </Paragraph>
 
+      {/* TODO: refactor this GRID into shared component for Expertise */}
       <div className="mt-10 w-full">
-        <div className="flex w-full flex-col gap-6 lg:flex-row">
-          <div className="flex w-full flex-col gap-6 md:flex-row lg:w-2/3">
-            <ExpertiseSection icon={ICON_EMOJI.atomSymbol} heading="React Dev" listItems={careerReactDev} />
-            <ExpertiseSection icon={ICON_EMOJI.laptop} heading="Web Dev" listItems={careerWebDev} />
+        <div className="grid w-full gap-6 lg:grid-cols-3">
+          <div className="grid w-full gap-6 md:grid-cols-2 lg:col-span-2">
+            <ExpertiseSection icon={ICON_EMOJI.atomSymbol} heading={TEXT.reactDev} listItems={careerReactDev} />
+            <ExpertiseSection icon={ICON_EMOJI.laptop} heading={TEXT.webDev} listItems={careerWebDev} />
           </div>
-          <div className="flex w-full lg:w-1/3">
-            <ExpertiseSection icon={ICON_EMOJI.cog} heading="Testing" listItems={careerTesting} />
+          <div className="w-full">
+            <ExpertiseSection icon={ICON_EMOJI.cog} heading={TEXT.testing} listItems={careerTesting} />
           </div>
         </div>
       </div>

--- a/lib/data/pages/projects/personal/projects-overview/next/personalNext.ts
+++ b/lib/data/pages/projects/personal/projects-overview/next/personalNext.ts
@@ -31,7 +31,7 @@ export const projectsPersonalNext: Project[] = [
     company: 'Personal project',
     role: 'Front End - Next.js',
     description:
-      'My personal portfolio website to showcase my work and skills. The\u00A0latest iteration of what I know and can code as React Developer.',
+      'My personal portfolio website to showcase my work and skills I have. Production level code that I code as React Developer.',
     skillsIcons: iconsSkillsProjectsPersonalKrsiak,
     skillsOverview: [
       {

--- a/lib/data/pages/projects/personal/projects-overview/react/personalReact.ts
+++ b/lib/data/pages/projects/personal/projects-overview/react/personalReact.ts
@@ -31,7 +31,7 @@ export const projectsPersonalReact: Project[] = [
     company: 'Personal project',
     role: 'Front End - React',
     description:
-      'Crypto currency prices app fetching latest data from CoinGecko API. This is fun little project created in Chakra UI with dark mode available.',
+      'Crypto currency prices app fetching latest data from CoinGecko API. This\u00A0is very small project in Chakra UI with dark mode.',
     skillsIcons: iconsSkillsProjectsPersonalCryptomania,
     skillsOverview: [
       {

--- a/lib/data/pages/projects/work/projects-overview/front-end/workFrontEnd.ts
+++ b/lib/data/pages/projects/work/projects-overview/front-end/workFrontEnd.ts
@@ -32,7 +32,7 @@ export const projectsWorkFrontEnd: Project[] = [
     role: 'Front End Developer',
     years: '1\u00A0year',
     description:
-      'I created the company website Front End. I worked closely with the\u00A0main UX designer on new brand color theme and layout decisions.',
+      'I created SaaS company website and was responsible for Front End. I\u00A0worked with the\u00A0main UX designer on new brand color theme.',
     skillsIcons: iconsSkillsProjectsWorkSmartsuppWeb,
     skillsOverview: [
       {

--- a/lib/data/pages/projects/work/projects-overview/localization/workLocalization.ts
+++ b/lib/data/pages/projects/work/projects-overview/localization/workLocalization.ts
@@ -30,7 +30,7 @@ export const projectsWorkLocalization: Project[] = [
     role: 'QA Automation - Team Leader',
     years: '1 year',
     description:
-      'I had amazing chance to be team leader on Microsoft products, doing quality checks for Microsoft projects Windows 8 + Windows Phone.',
+      'Worked\u00A0on\u00A0localization testing for Microsoft Windows 8 + Windows Phone. I\u00A0had\u00A0an\u00A0amazing chance to be team leader on Microsoft products.',
     skillsIcons: iconsSkillsProjectsWorkMoravia,
     skillsOverview: [
       {

--- a/lib/data/pages/projects/work/projects-overview/quality-assurance/workQA.ts
+++ b/lib/data/pages/projects/work/projects-overview/quality-assurance/workQA.ts
@@ -28,7 +28,7 @@ export const projectsWorkQA: Project[] = [
     role: 'QA Automation - Team Leader',
     years: '4\u00A0months',
     description:
-      'I was responsible setting up new QA team, related processes, hiring and managing people, making test plans, test cases, and scripts.',
+      'I was responsible setting up new QA team, hiring and managing people. Setting up QA processes, writing test plans, and testing scripts.',
     skillsIcons: iconsSkillsProjectsWorkGroupon,
     skillsOverview: [
       {

--- a/lib/data/pages/projects/work/projects-overview/react/workReactKomercniBanka.ts
+++ b/lib/data/pages/projects/work/projects-overview/react/workReactKomercniBanka.ts
@@ -31,7 +31,7 @@ export const workReactKomercniBanka: Project = {
   role: 'React Developer',
   years: '10\u00A0months',
   description:
-    'I created search page for ATM and branches, with their detail pages. And also Exchange rates page with details for each currency.',
+    'I created search page for ATM and branches, with their detail pages. And\u00A0also Exchange rates page with details for each currency.',
   skillsIcons: iconsSkillsProjectsWorkKomercniBanka,
   skillsOverview: [
     {

--- a/lib/data/pages/projects/work/projects-overview/react/workReactKooperativa.ts
+++ b/lib/data/pages/projects/work/projects-overview/react/workReactKooperativa.ts
@@ -28,7 +28,8 @@ export const workReactKooperativa: Project = {
   company: 'Kooperativa',
   role: 'React Developer',
   years: '8\u00A0months',
-  description: 'I worked on an application for managing insurance policies for citizens property and products.',
+  description:
+    'I worked on an application for managing insurance policies for citizens. Kooperativa has over 2 480 000+ customers in Czech Republic.',
   skillsIcons: iconsSkillsProjectsWorkKooperativa,
   skillsOverview: [
     {

--- a/lib/data/pages/projects/work/projects-overview/react/workReactSmartsuppDashboard.ts
+++ b/lib/data/pages/projects/work/projects-overview/react/workReactSmartsuppDashboard.ts
@@ -3,7 +3,7 @@ import { iconsSkillsProjectsWorkSmartsuppDashboard } from '@/lib/data/pages/proj
 import { PROJECT_ID } from '@/lib/utils/constants/ids/projectIds'
 import { PAGES_URL } from '@/lib/utils/constants/urls/pageUrls'
 
-import { ICON_EMOJI } from '@/localization/english'
+import { ICON_EMOJI, TEXT } from '@/localization/english'
 
 import { SkillCategoryEnum, SkillsEnum } from '@/lib/utils/typeDefinitions/enums'
 import { Project } from '@/lib/utils/typeDefinitions/interfaces'
@@ -26,12 +26,12 @@ export const workReactSmartsuppDashboard: Project = {
     { id: 4, src: smartsuppDashboard4.src },
   ],
   icon: ICON_EMOJI.speechBalloon,
-  title: 'Chat Dashboard',
+  title: TEXT.customerCareChatDashboard,
   company: 'Smartsupp',
   role: 'React Developer',
   years: '3\u00A0years 2\u00A0months',
   description:
-    'I worked on chat dashboard features and new design, including redesign of settings. I was involved in UX team to learn.',
+    'I worked on chat dashboard features and new design of settings. I\u00A0was\u00A0involved in UX team learning about user needs.',
   skillsIcons: iconsSkillsProjectsWorkSmartsuppDashboard,
   skillsOverview: [
     {

--- a/lib/data/pages/projects/work/projects-overview/wordpress/workWordpress.ts
+++ b/lib/data/pages/projects/work/projects-overview/wordpress/workWordpress.ts
@@ -30,7 +30,7 @@ export const projectsWorkWordPress: Project[] = [
     role: 'Admin &\u00A0Content Writer',
     years: '6\u00A0months',
     description:
-      'Responsible for the company HELP website running on WordPress and\u00A0writing tutorials. Localization into 9 languages.',
+      'Localization of the company HELP website into 9 languages. I\u00A0was\u00A0also\u00A0writing tutorials and creating content.',
     skillsIcons: iconsSkillsProjectsWorkSmartsuppHelp,
     skillsOverview: [
       {

--- a/lib/data/pages/testimonials/personalTestimonials.ts
+++ b/lib/data/pages/testimonials/personalTestimonials.ts
@@ -11,7 +11,7 @@ export const personalTestimonials: TestimonialItem[] = [
     personPhoto: personMoorhead,
     personIcon: ICON_EMOJI.latinCross,
     personName: TEXT.nameMoorhead,
-    personJob: 'Baptist Pastor ~ Grace Community Church',
+    personJob: 'Baptist Pastor ~\u00A0Grace\u00A0Community\u00A0Church',
     testimonialText: `
       I have known Daniel for almost a decade and he has always proven himself faithful.
       He has always been very dedicated to his employment, and has always been very respectful in his words and opinions.

--- a/lib/data/pages/testimonials/workTestimonials.ts
+++ b/lib/data/pages/testimonials/workTestimonials.ts
@@ -13,7 +13,7 @@ export const workTestimonials: TestimonialItem[] = [
     personPhoto: personLosseff,
     personIcon: ICON_EMOJI.woman.officeWorker,
     personName: TEXT.nameLosseff,
-    personJob: 'Linguistic Services ~\u00A0Moravia IT',
+    personJob: 'Linguistic Services ~\u00A0Moravia\u00A0IT',
     testimonialText: `
       Daniel is strong in creating automation utilities, term processing, all kinds of\u00A0tracking.
       He has gained a lot of\u00A0experience in\u00A0bug processing.
@@ -35,7 +35,7 @@ export const workTestimonials: TestimonialItem[] = [
     personPhoto: personPridalek,
     personIcon: ICON_EMOJI.man.officeWorker,
     personName: TEXT.namePridalek,
-    personJob: 'Senior Localization Group Manager ~\u00A0Moravia IT',
+    personJob: 'Senior Localization Group Manager ~\u00A0Moravia\u00A0IT',
     testimonialText: `
       Daniel helped team with engineering skills, automating bug management tasks.
       In\u00A0the\u00A0role of\u00A0bug-fixing engineer, he bridged linguistic managers and\u00A0production teams.

--- a/localization/english.ts
+++ b/localization/english.ts
@@ -160,7 +160,9 @@ export const STATUS_PAGE = {
 }
 
 export const COMPANIES = {
-  smartsuppDashboard: 'Smartsupp — Chat Dashboard',
+  smartsuppDashboard: 'Smartsupp Dashboard',
+  customerCareChatDashboard: 'Chat Dashboard',
+  smartsuppChatDashboard: 'Smartsupp — Chat Dashboard',
   komercniBanka: 'Komerční banka',
   kooperativa: 'Kooperativa',
   smartsuppWeb: 'Smartsupp — Web',
@@ -186,6 +188,10 @@ export const MY_WORK = {
   skillsForCompany: 'Skills',
   committedMindset: 'Mindset',
   problemSolving: 'Creative',
+  reactDev: 'React Dev',
+  webDev: 'Web Dev',
+  testing: 'Testing',
+  myJourney: 'My journey:',
 }
 
 export const MISC = {
@@ -394,7 +400,7 @@ export const META_SMARTSUPP_DASHBOARD = {
     nameDanielKrsiak: COMMON_VALUES.nameDanielKrsiak,
     reactDeveloper: COMMON_VALUES.reactDeveloper,
     smartsuppDashboard: 'Smartsupp Dashboard',
-    customerCareChatDashboard: 'Chat Dashboard',
+    chatDashboard: 'Chat Dashboard',
     javaScript: COMMON_VALUES.javaScript,
     typeScript: COMMON_VALUES.typeScript,
     react: COMMON_VALUES.react,
@@ -576,6 +582,7 @@ export const IMAGE_ALT = {
   microsoft: 'Microsoft',
   smartsupp: 'Smartsupp',
   kooperativa: 'Kooperativa',
+  groupon: 'Groupon',
   ibm: 'IBM',
   rwsMoravia: 'RWS - Moravia',
   komercniBanka: 'Komerční Banka',


### PR DESCRIPTION
Issue: `n/a`

> [!NOTE]
> **TL;DR:** Made adjustments to layout in code. Also updated texts and made them to fit responsive layouts better.

---

This pull request includes several changes to improve the layout and consistency of various components in the project, as well as updates to text content and removal of unused imports.

### Layout improvements:
* Updated the layout of icons and text in multiple components, such as `Resume`, `StatusPage`, `Testimonials`, and `ProjectsOverviewLayout`, to add consistent spacing and remove unnecessary margins. [[1]](diffhunk://#diff-a5b785c3ffb49da984a7500ded3bac0c137dd04408950109151ba71e63aeea8aL33-R36) [[2]](diffhunk://#diff-dbcf63510b1780449b698dd6ef6d84bafb096c9fecf7317e87a0725483cb7bf1L34-R37) [[3]](diffhunk://#diff-2b61d18bfe1049b2242d467f60e460ffa76ce28d0864a825f66b2682d512d883L37-R40) [[4]](diffhunk://#diff-f1c05a971d00641ca1fab63b2e5bf774f1e92658bcdcf067efa89d028f75b275L17-R20)
* Refactored the `MyExpertise` and `CareerPath` components to use a grid layout instead of flexbox for better responsiveness. [[1]](diffhunk://#diff-12714478f97a68d299fad5af44d72402555e80fb1d1cbb4af8ee1c5f3136e539L17-R19) [[2]](diffhunk://#diff-5d7165804ff3f0f8c8d04cd872b8afe16cbcebb75bbb5f8d8ef1f915515107f0L20-R35)

###  Component refactoring:
* Refactored the `Companies` component to use a grid layout for displaying logos and removed the unused `ibm` import. [[1]](diffhunk://#diff-f5a936cc8d51807caa770d090e756759769710aaf34f35187a6517f34f2d1bafL10) [[2]](diffhunk://#diff-f5a936cc8d51807caa770d090e756759769710aaf34f35187a6517f34f2d1bafL37-R59)

###  Text content updates:
* Updated project descriptions in various files to improve clarity and readability. [[1]](diffhunk://#diff-ba32fd9d26b797c4ff25de34987e1c16480f0b667cb65af2804ed13459b15774L34-R34) [[2]](diffhunk://#diff-4d0e2a34bb8916398a520d40fe0ddc51041a17be89fa4ba9b9c671ae545011a9L34-R34) [[3]](diffhunk://#diff-4d80a4d77fb59a970f3bac6394a4e21d0543dbf1235c981f866b0680bce11bbcL35-R35) [[4]](diffhunk://#diff-dfdeb24a6745b273eb38beb468ecd69613c5c603247e2f3272684d2ee8dbc855L33-R33) [[5]](diffhunk://#diff-99a11a8b57b780618f4cd66fa8cbc4e86f65faed38dc90b238929d771ded6363L31-R31) [[6]](diffhunk://#diff-6f96eb3ca55178abab0f28c087e4a8a9da5fe7e5a67e9e10cdf1c59d519860d8L34-R34) [[7]](diffhunk://#diff-d3449727f07b23d910f7a20f28dec03ee1f5462be915cf6c9b3ad49fa27a68a9L31-R32) [[8]](diffhunk://#diff-444666953fc1c327bf03b2283a98299cf4294d035ea470309508e49dd9f9f1e5L29-R34)
