### PR TITLE
refactor(testimonials): 👷  Order of content

### DIFF
--- a/app/testimonials/page.tsx
+++ b/app/testimonials/page.tsx
@@ -44,6 +44,14 @@ const Testimonials: FC = (): JSX.Element => {
           <TestimonialsIntroduction />
         </div>
 
+        {/* Office Work */}
+        <TestimonialsSection
+          title={TESTIMONIALS.sections.professional.title}
+          icon={ICON_EMOJI.manTechnologist.lightSkinTone}
+          description={TESTIMONIALS.sections.professional.description}
+          testimonials={workTestimonials}
+        />
+
         {/* Character */}
         <TestimonialsSection
           title={TESTIMONIALS.sections.character.title}
@@ -58,14 +66,6 @@ const Testimonials: FC = (): JSX.Element => {
           icon={ICON_EMOJI.personLiftingWeights}
           description={TESTIMONIALS.sections.fitnessCoach.description}
           testimonials={fitnessCoachTestimonials}
-        />
-
-        {/* Office Work */}
-        <TestimonialsSection
-          title={TESTIMONIALS.sections.professional.title}
-          icon={ICON_EMOJI.manTechnologist.lightSkinTone}
-          description={TESTIMONIALS.sections.professional.description}
-          testimonials={workTestimonials}
         />
         <CallToActionLinkedIn />
       </div>


### PR DESCRIPTION
This pull request reorganizes the layout of the `Testimonials` page.

Reordering of testimonials sections:

* Moved the "Office Work" testimonials section, which includes the title, icon, description, and testimonials data, to appear before the "Character" testimonials section. (`app/testimonials/page.tsx`, [[1]](diffhunk://#diff-2b61d18bfe1049b2242d467f60e460ffa76ce28d0864a825f66b2682d512d883R47-R54) [[2]](diffhunk://#diff-2b61d18bfe1049b2242d467f60e460ffa76ce28d0864a825f66b2682d512d883L62-L69)