### PR TITLE
chore(dependabot): 🛠️ schedule monthly and ignored dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,15 @@ updates:
   - package-ecosystem: 'npm'
     # Look for `package.json` and `lock` files in the `root` directory
     directory: '/'
-    # Check the npm registry for updates every day (weekdays)
+    # Check the npm registry for updates
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
+    # Ignore updates for specified packages
+    ignore:
+      - dependency-name: "flowbite"
+      - dependency-name: "flowbite-react"
+      - dependency-name: "react"
+      - dependency-name: "react-dom"
+      - dependency-name: "@types/react"
+      - dependency-name: "@types/react-dom"
+      - dependency-name: "tailwindcss"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,10 +12,10 @@ updates:
       interval: 'monthly'
     # Ignore updates for specified packages
     ignore:
-      - dependency-name: "flowbite"
-      - dependency-name: "flowbite-react"
-      - dependency-name: "react"
-      - dependency-name: "react-dom"
-      - dependency-name: "@types/react"
-      - dependency-name: "@types/react-dom"
-      - dependency-name: "tailwindcss"
+      - dependency-name: 'flowbite'
+      - dependency-name: 'flowbite-react'
+      - dependency-name: 'react'
+      - dependency-name: 'react-dom'
+      - dependency-name: '@types/react'
+      - dependency-name: '@types/react-dom'
+      - dependency-name: 'tailwindcss'


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` configuration.

Dependabot configuration updates:

* Changed the update schedule for the `npm` package ecosystem from weekly to monthly.
* Added an ignore list for specific dependencies, including `flowbite`, `flowbite-react`, `react`, `react-dom`, `@types/react`, `@types/react-dom`, and `tailwindcss`.