### PR TITLE
refactor(quote): 👷 who I am - new author

### DIFF
--- a/app/who-i-am/page.tsx
+++ b/app/who-i-am/page.tsx
@@ -54,7 +54,6 @@ const WhoIAm: FC = (): JSX.Element => {
           <WhoIAmTravelsList />
         </section>
 
-        {/* Quotes and photos of South Korea */}
         <SouthKorea />
       </div>
 

--- a/components/pages/who-i-am/SouthKorea.tsx
+++ b/components/pages/who-i-am/SouthKorea.tsx
@@ -38,9 +38,11 @@ const SouthKorea: FC = (): JSX.Element => {
             <TestimonialQuote />
             <TestimonialText text={SOUTH_KOREA.quote1} />
             <Paragraph marginTop="mt-2" customCss="flex">
-              {SOUTH_KOREA.quoteAuthor1}
-              <span role="img" aria-label={ARIA_LABELS.emoji.writingHand} className="ml-1">
-                {ICON_EMOJI.writingHand}
+              <span role="img" aria-label={ARIA_LABELS.emoji.starAndCrescent} className="ml-1">
+                {ICON_EMOJI.starAndCrescent}
+              </span>
+              <span className="ml-2">
+                {SOUTH_KOREA.quoteAuthorName1}, {SOUTH_KOREA.quoteAuthorOccupation1}
               </span>
             </Paragraph>
           </div>
@@ -63,9 +65,11 @@ const SouthKorea: FC = (): JSX.Element => {
             <TestimonialQuote />
             <TestimonialText text={SOUTH_KOREA.quote2} />
             <Paragraph marginTop="mt-2" customCss="flex">
-              {SOUTH_KOREA.quoteAuthor2}
               <span role="img" aria-label={ARIA_LABELS.emoji.latinCross} className="ml-1">
                 {ICON_EMOJI.latinCross}
+              </span>
+              <span className="ml-2">
+                {SOUTH_KOREA.quoteAuthorName2}, {SOUTH_KOREA.quoteAuthorOccupation2}
               </span>
             </Paragraph>
           </div>

--- a/localization/english.ts
+++ b/localization/english.ts
@@ -4,6 +4,7 @@ import { YEARS } from '@/lib/utils/constants/yearsExperience'
 
 export const ICON_EMOJI = {
   latinCross: '✝️',
+  starAndCrescent: '☪️',
   flagCzechRepublic: '🇨🇿',
   flagUnitedKingdom: '🇬🇧',
   flagSpain: '🇪🇸',
@@ -740,12 +741,13 @@ export const SOUTH_KOREA = {
   headingSouthKorea: 'South Korea',
   introduction:
     'South Korea is\u00A0a\u00A0fascinating country where ancient traditions seamlessly meet modern innovation, offering a\u00A0captivating journey through bustling metropolitan cities like\u00A0Seoul, serene Buddhist temples, stunning mountain vistas, and\u00A0nature full of\u00A0lush forests and\u00A0beautiful rivers.',
-  quote1:
-    'Travel makes one modest. You see what a\u00A0tiny place you occupy in\u00A0the\u00A0world.',
-  quoteAuthor1: 'Gustave Flaubert, Novelist',
+  quote1: 'Traveling—it leaves you speechless, then turns you into a\u00A0storyteller.',
+  quoteAuthorName1: 'Ibn Battuta',
+  quoteAuthorOccupation1: '14th-century explorer',
   quote2:
     'The world is\u00A0a\u00A0book, and\u00A0those who do\u00A0not travel read only one page.',
-  quoteAuthor2: 'Saint Augustine, Bishop',
+  quoteAuthorName2: 'Saint Augustine',
+  quoteAuthorOccupation2: 'Bishop of Hippo',
   hiking: 'South Korea - hiking',
   nature: 'South Korea - nature',
   temple: 'South Korea - temple',
@@ -884,6 +886,7 @@ export const ARIA_LABELS = {
   galleryThumbnail: 'Thumbnail',
   emoji: {
     icon: 'Emoji',
+    starAndCrescent: 'Star and crescent',
     latinCross: 'Latin cross',
     house: 'House',
     moneyBag: 'Money bag',


### PR DESCRIPTION
This pull request updates the `SouthKorea` component and its associated localization data to enhance the presentation of quotes and their authors. It also introduces new emoji constants and aria labels for improved accessibility and representation.

### Component Enhancements:

* [`components/pages/who-i-am/SouthKorea.tsx`](diffhunk://#diff-6cf99c6b184af05392086190de7f4f8882c31e468e6f51a26073d99b40a8fd6fL41-R45): Updated the quotes section to include detailed author information (name and occupation) and replaced the `writingHand` emoji with the `starAndCrescent` emoji for the first quote. [[1]](diffhunk://#diff-6cf99c6b184af05392086190de7f4f8882c31e468e6f51a26073d99b40a8fd6fL41-R45) [[2]](diffhunk://#diff-6cf99c6b184af05392086190de7f4f8882c31e468e6f51a26073d99b40a8fd6fL66-R73)

### Localization Updates:

* [`localization/english.ts`](diffhunk://#diff-56f60b3fd203762cbec540ddf7d4e9c68ead8992ead4bacec6f9a44913368ef7R7): Added `starAndCrescent` emoji constant and its corresponding aria label. Updated the `SOUTH_KOREA` quotes to reflect new text and split author details into `quoteAuthorName` and `quoteAuthorOccupation` fields for better clarity. [[1]](diffhunk://#diff-56f60b3fd203762cbec540ddf7d4e9c68ead8992ead4bacec6f9a44913368ef7R7) [[2]](diffhunk://#diff-56f60b3fd203762cbec540ddf7d4e9c68ead8992ead4bacec6f9a44913368ef7L743-R750) [[3]](diffhunk://#diff-56f60b3fd203762cbec540ddf7d4e9c68ead8992ead4bacec6f9a44913368ef7R889)

### Minor Cleanup:

* [`app/who-i-am/page.tsx`](diffhunk://#diff-a3bd0b6835cf12b09e07240104d5d8b08ae75fb144d91bead9c2cf8fd1afa54dL57): Removed a redundant comment about quotes and photos of South Korea.