### PR TITLE
chore(deps): 🛠️ remove flowbite

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -15,7 +15,7 @@
   html,
   body {
     font-family: 'Roboto', sans-serif;
-    background-color: #f9fafb; /* 'bg-gray-50': https://flowbite.com/docs/customize/colors/ */
+    background-color: #f9fafb; /* 'bg-gray-50' */
   }
 
   /* ## Set font RUBIK */

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,6 @@
         "@next/third-parties": "15.3.5",
         "@types/hast": "^3.0.4",
         "@types/mdx": "^2.0.13",
-        "flowbite": "^2.5.2",
         "gray-matter": "^4.0.3",
         "lunarphase-js": "^2.0.3",
         "react": "^18",
@@ -470,8 +469,6 @@
     "@pkgr/core": ["@pkgr/core@0.2.7", "", {}, "sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg=="],
 
     "@playwright/test": ["@playwright/test@1.53.2", "", { "dependencies": { "playwright": "1.53.2" }, "bin": { "playwright": "cli.js" } }, "sha512-tEB2U5z74ebBeyfGNZ3Jfg29AnW+5HlWhvHtb/Mqco9pFdZU1ZLNdVb2UtB5CvmiilNr2ZfVH/qMmAROG/XTzw=="],
-
-    "@popperjs/core": ["@popperjs/core@2.11.8", "", {}, "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="],
 
     "@rollup/plugin-babel": ["@rollup/plugin-babel@5.3.1", "", { "dependencies": { "@babel/helper-module-imports": "^7.10.4", "@rollup/pluginutils": "^3.1.0" }, "peerDependencies": { "@babel/core": "^7.0.0", "@types/babel__core": "^7.1.9", "rollup": "^1.20.0||^2.0.0" }, "optionalPeers": ["@types/babel__core"] }, "sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q=="],
 
@@ -1063,10 +1060,6 @@
 
     "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
 
-    "flowbite": ["flowbite@2.5.2", "", { "dependencies": { "@popperjs/core": "^2.9.3", "flowbite-datepicker": "^1.3.0", "mini-svg-data-uri": "^1.4.3" } }, "sha512-kwFD3n8/YW4EG8GlY3Od9IoKND97kitO+/ejISHSqpn3vw2i5K/+ZI8Jm2V+KC4fGdnfi0XZ+TzYqQb4Q1LshA=="],
-
-    "flowbite-datepicker": ["flowbite-datepicker@1.3.2", "", { "dependencies": { "@rollup/plugin-node-resolve": "^15.2.3", "flowbite": "^2.0.0" } }, "sha512-6Nfm0MCVX3mpaR7YSCjmEO2GO8CDt6CX8ZpQnGdeu03WUCWtEPQ/uy0PUiNtIJjJZWnX0Cm3H55MOhbD1g+E/g=="],
-
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
@@ -1524,8 +1517,6 @@
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
-
-    "mini-svg-data-uri": ["mini-svg-data-uri@1.4.4", "", { "bin": { "mini-svg-data-uri": "cli.js" } }, "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg=="],
 
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@next/third-parties": "15.3.5",
     "@types/hast": "^3.0.4",
     "@types/mdx": "^2.0.13",
-    "flowbite": "^2.5.2",
     "gray-matter": "^4.0.3",
     "lunarphase-js": "^2.0.3",
     "react": "^18",
@@ -74,7 +73,7 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
-      "bun next lint --fix --max-warnings=0",
+      "bun eslint --fix --max-warnings=0",
       "bun prettier --write"
     ],
     "*.{css,scss,md,mdx,json,yml}": [

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -75,7 +75,6 @@ const customScreenSizes = {
 const config: Config = {
   // Config file for Tailwind CSS
   content: [
-    './node_modules/flowbite-react/lib/**/*.js',
     './app/**/*.{js,ts,jsx,tsx,mdx}', // New - https://nextjs.org/docs/app
     './pages/**/*.{js,ts,jsx,tsx,mdx}', // Old version - https://nextjs.org/docs/pages/building-your-application/routing
     './components/**/*.{js,ts,jsx,tsx,mdx}',
@@ -136,7 +135,7 @@ const config: Config = {
     },
   },
   // Plugins
-  plugins: [require('flowbite/plugin')],
+  plugins: [],
 }
 
 export default config


### PR DESCRIPTION
This pull request includes several changes related to the removal of the Flowbite library and updates to project configurations. The most important changes focus on cleaning up dependencies, modifying linting commands, and adjusting Tailwind CSS configurations.

### Removal of Flowbite:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L34): Removed the `flowbite` dependency from the project.
* [`tailwind.config.ts`](diffhunk://#diff-655dc9e3d0aa561e3fa164bf48bd89cb0f5da65e0a567f8ebbf9dd791a0e7f40L78): Removed Flowbite-specific content paths and the `flowbite/plugin` entry from the Tailwind CSS configuration. [[1]](diffhunk://#diff-655dc9e3d0aa561e3fa164bf48bd89cb0f5da65e0a567f8ebbf9dd791a0e7f40L78) [[2]](diffhunk://#diff-655dc9e3d0aa561e3fa164bf48bd89cb0f5da65e0a567f8ebbf9dd791a0e7f40L139-R138)

### Linting Configuration Update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L77-R76): Updated the lint-staged configuration to replace the `bun next lint` command with `bun eslint`. This ensures the use of `eslint` directly for linting JavaScript and TypeScript files.

### Minor Comment Update:

* [`app/globals.css`](diffhunk://#diff-79e0914d9fee5ca4432bdb002a24d700d31b5577265f4de3f90d5c292b9f1392L18-R18): Updated a comment by removing an unnecessary URL reference for the `bg-gray-50` color.