### PR TITLE
build(labeler): 🏗️ update config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,6 +14,9 @@ CICD:
 Dependabot:
   - head-branch: ['^dependabot', 'dependabot', '.*dependabot.*']
 
+Dependencies:
+  - head-branch: ['^deps', 'deps', '.*deps.*']
+
 Docs:
   - head-branch: ['^docs', 'docs', '.*docs.*']
 
@@ -36,7 +39,7 @@ Performance:
   - head-branch: ['^perf', 'perf', '.*perf.*', '^performance', 'performance', '.*performance.*']
 
 Refactor:
-  - head-branch: ['^ref', 'ref', '.*ref.*', ^refactor', 'refactor', '.*refactor.*']
+  - head-branch: ['^ref', 'ref', '.*ref.*', '^refactor', 'refactor', '.*refactor.*']
 
 Revert:
   - head-branch: ['^revert', 'revert', '.*revert.*']


### PR DESCRIPTION
This pull request updates the `.github/labeler.yml` configuration to improve automated labeling of pull requests based on branch naming conventions. The main changes are the addition of a new label for dependency updates and a fix to an existing label pattern.

Labeling improvements:

* Added a new `Dependencies` label that will automatically apply to pull requests with branch names matching common dependency update patterns (e.g., starting with or containing `deps`).
* Fixed a typo in the `Refactor` label pattern by correcting the missing quote, ensuring branches starting with or containing `refactor` are properly labeled.