### PR TITLE
refactor(playwright): 👷 config workers

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,8 +40,8 @@ export default defineConfig({
   // Retry on CI only
   retries: process.env['CI'] ? CI_RETRIES : 0,
 
-  // Opt out of parallel tests on CI. On localhost 'undefined' sets workers based on CPU.
-  workers: process.env['CI'] ? CI_WORKERS : undefined,
+  // Number of parallel workers (3 in CI, 1 locally)
+  workers: process.env['CI'] ? CI_WORKERS : 1,
 
   //Reporter to use. https://playwright.dev/docs/test-reporters
   reporter: process.env['CI']


### PR DESCRIPTION
This pull request updates the Playwright test configuration to set the number of parallel workers to 1 when running locally, instead of using the default based on CPU cores. This change ensures consistent test execution locally.

Test configuration update:

* In `playwright.config.ts`, the `workers` setting is now explicitly set to 1 for local runs, and to `CI_WORKERS` in CI environments, rather than being left undefined locally.