### PR TITLE
style(css): 🎨  breadcrumbs vcard navigation

### DIFF
--- a/components/layout/footer/Footer.tsx
+++ b/components/layout/footer/Footer.tsx
@@ -7,13 +7,10 @@ import PageContainer from '@/components/layout/PageContainer'
 import DividerWithText from '@/components/shared/DividerWithText'
 import ScanMyContactQR from '@/components/shared/ScanMyContactQR'
 
-import { DIVIDER_WITH_TEXT, ARIA_LABELS } from '@/localization/english'
+import { ARIA_LABELS, DIVIDER_WITH_TEXT } from '@/localization/english'
 
 import { ID } from '@/lib/utils/constants/ids/elementIds'
 import ScrollToTopButton from './ScrollToTopButton'
-
-const IMAGE_WIDTH = 216
-const IMAGE_HEIGHT = 216
 
 const Footer: FC = (): JSX.Element => {
   return (
@@ -24,7 +21,7 @@ const Footer: FC = (): JSX.Element => {
         <div className="mx-auto mt-20 flex w-full flex-col items-center justify-center pb-16">
           <div>
             <DividerWithText text={DIVIDER_WITH_TEXT.contactMe} />
-            <ScanMyContactQR width={IMAGE_WIDTH} height={IMAGE_HEIGHT} showImageCaption={false} />
+            <ScanMyContactQR showImageCaption={false} />
           </div>
 
           <Status />

--- a/components/layout/header/menu/Menu.tsx
+++ b/components/layout/header/menu/Menu.tsx
@@ -35,9 +35,7 @@ const Menu: FC<MenuProps> = ({ type, ref, onClickLink }): JSX.Element => {
         ref={ref}
         role="menubar"
         aria-orientation={isMobile ? 'vertical' : 'horizontal'}
-        className={
-          isMobile ? 'mt-2 mb-6 flex flex-col gap-1 lg:hidden' : 'hidden gap-2 lg:flex 2xl:gap-2'
-        }
+        className={isMobile ? 'mt-2 mb-6 flex flex-col gap-2 lg:hidden' : 'hidden gap-2 lg:flex'}
       >
         {(pagesLinks ?? []).map((link) => {
           // Create a new link object with the active state

--- a/components/layout/header/menu/MenuItem.tsx
+++ b/components/layout/header/menu/MenuItem.tsx
@@ -7,10 +7,10 @@ import { MenuItemProps } from '@/lib/utils/typeDefinitions/props/layout/header/m
 const MenuItem: FC<MenuItemProps> = ({ linkItem, isMobile, onClickLink }): JSX.Element => {
   const { id, href, icon, ariaLabel, text, dataTestId, isActive } = linkItem
 
-  const mobileDesktopCSS = isMobile ? 'border-b border-gray-100 py-3' : 'py-2'
+  const mobileDesktopCSS = isMobile ? 'py-3' : 'py-2'
   const hoverAndFocusCSS = 'hover:border-violet-50 hover:bg-violet-50'
   const sharedCss =
-    'text-md block select-none rounded-lg px-4 md:px-1 lg:px-1.5 xl:px-2 font-bold transition-all duration-200 ease-in-out'
+    'text-md block select-none rounded-lg px-4 lg:px-3 xl:px-4 bg-neutral-50 font-bold transition-all duration-200 ease-in-out'
 
   // Active state styling
   const activeCSS = isActive

--- a/components/layout/page-navigation/PageNavigation.tsx
+++ b/components/layout/page-navigation/PageNavigation.tsx
@@ -28,7 +28,7 @@ const PageNavigation: FC<PageNavigationProps> = ({
     <nav data-testid={DATA_TEST_IDS.navigation.END_OF_PAGE}>
       <div className="container mx-auto mt-20 max-w-(--breakpoint-xl)">
         <div
-          className={`group flex flex-col gap-8 md:flex-row ${hasPreviousLink ? 'justify-between' : 'justify-end'}`}
+          className={`group flex flex-col gap-4 md:flex-row ${hasPreviousLink ? 'justify-between' : 'justify-end'}`}
         >
           {hasPreviousLink ? (
             <PageNavigationLink

--- a/components/shared/BreadcrumbsItem.tsx
+++ b/components/shared/BreadcrumbsItem.tsx
@@ -23,7 +23,7 @@ const BreadcrumbsItem: FC<BreadcrumbsItemProps> = ({
       )}
       <Link
         href={href}
-        className={`rounded-lg px-0 py-2 text-sm font-medium text-neutral-600 select-none ${hoverAndFocusCSS}`}
+        className={`rounded-lg p-2 text-sm font-medium text-neutral-600 select-none ${hoverAndFocusCSS}`}
       >
         <span role="img" aria-label={ariaLabel} className="select-none">
           {icon}

--- a/components/shared/SocialLinkIcon.tsx
+++ b/components/shared/SocialLinkIcon.tsx
@@ -8,8 +8,8 @@ import { SocialLinkIconProps } from '@/lib/utils/typeDefinitions/props/shared/so
 const IMAGE_WIDTH_MOBILE = 32
 const IMAGE_HEIGHT_MOBILE = 32
 
-const IMAGE_WIDTH_DESKTOP = 24
-const IMAGE_HEIGHT_DESKTOP = 24
+const IMAGE_WIDTH_DESKTOP = 28
+const IMAGE_HEIGHT_DESKTOP = 28
 
 const SocialLinkIcon: FC<SocialLinkIconProps> = ({
   type,

--- a/lib/utils/typeDefinitions/types.ts
+++ b/lib/utils/typeDefinitions/types.ts
@@ -57,7 +57,19 @@ export type MarginTopType = 'mt-0' | 'mt-2' | 'mt-4' | 'mt-8' | 'mt-16'
 export type TextColorType = 'text-neutral-600' | 'text-neutral-700' | 'text-neutral-900'
 
 // Define possible text sizes
-export type TextSizeType = 'text-sm' | 'text-md' | 'text-lg' | 'text-xl' | 'text-2xl'
+export type TextSizeType =
+  | 'text-sm'
+  | 'text-md'
+  | 'text-lg'
+  | 'text-xl'
+  | 'text-2xl'
+  | 'text-3xl'
+  | 'text-4xl'
+  | 'text-5xl'
+  | 'text-6xl'
+  | 'text-7xl'
+  | 'text-8xl'
+  | 'text-9xl'
 
 // Define the type for the setLunarPhaseEmoji function
 export type SetLunarPhaseEmoji = (emoji: string) => void


### PR DESCRIPTION
This pull request focuses on UI refinements and minor code cleanups across several layout and shared components. The main goals are to improve visual consistency, provide more flexibility for text sizing, and simplify component usage. Below are the most important changes grouped by theme:

**UI and Styling Improvements:**

* Increased the desktop icon size in `SocialLinkIcon` from 24x24 to 28x28 for better visibility.
* Updated `MenuItem` styling by removing the border for mobile items and adjusting padding/background for a more consistent look.
* Adjusted the gap between navigation items in `PageNavigation` from 8 to 4 for tighter grouping on smaller screens.
* Changed `BreadcrumbsItem` link padding from `px-0 py-2` to uniform `p-2` for improved clickable area and consistency.
* Modified the menu gap in the header menu for mobile from `gap-1` to `gap-2` for better spacing.

**Component Simplification and Flexibility:**

* Removed unused `IMAGE_WIDTH` and `IMAGE_HEIGHT` constants from `Footer` and simplified `ScanMyContactQR` usage by omitting explicit width/height props. [[1]](diffhunk://#diff-611eaedaa6407f44ed1f4a2c40cf955d8e37de47149102d1e73852f6641eca78L10-L17) [[2]](diffhunk://#diff-611eaedaa6407f44ed1f4a2c40cf955d8e37de47149102d1e73852f6641eca78L27-R24)

**Type Definition Enhancements:**

* Expanded `TextSizeType` to include larger text sizes (`text-3xl` through `text-9xl`), allowing for greater flexibility in typography throughout the app.