### PR TITLE
refactor(vcard): 👷 size and text

### DIFF
--- a/components/pages/resume/CareerPath.tsx
+++ b/components/pages/resume/CareerPath.tsx
@@ -19,8 +19,8 @@ const CareerPath = () => {
       </Paragraph>
 
       <div className="mt-10 w-full">
-        <div className="flex flex-col gap-6">
-          <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-8">
+          <div className="flex flex-col gap-8">
             <ExpertiseSection
               icon={ICON_EMOJI.atomSymbol}
               ariaLabel={ARIA_LABELS.emoji.atomSymbol}

--- a/components/pages/resume/ResumeContact.tsx
+++ b/components/pages/resume/ResumeContact.tsx
@@ -5,6 +5,7 @@ import ScanMyContactQR from '@/components/shared/ScanMyContactQR'
 
 import { RESUME, SHARED, TEXT } from '@/localization/english'
 
+import { QR_CODE } from '@/components/shared/constants'
 import { IS_OPEN_TO_WORK } from '@/lib/utils/constants/shared/openToWork'
 
 const ResumeContact = () => {
@@ -30,7 +31,11 @@ const ResumeContact = () => {
       </div>
 
       <div className="mt-10 flex">
-        <ScanMyContactQR showImageCaption={true} />
+        <ScanMyContactQR
+          width={QR_CODE.LARGE.WIDTH}
+          height={QR_CODE.LARGE.HEIGHT}
+          showImageCaption={true}
+        />
       </div>
     </>
   )

--- a/components/shared/ScanMyContactQR.tsx
+++ b/components/shared/ScanMyContactQR.tsx
@@ -11,8 +11,8 @@ import contactQR from '@/public/images/svg/vcard-contact/krsiak-daniel-qr-code-v
 import { QR_CODE } from './constants'
 
 const ScanMyContactQR = ({
-  width = QR_CODE.WIDTH,
-  height = QR_CODE.HEIGHT,
+  width = QR_CODE.SMALL.WIDTH,
+  height = QR_CODE.SMALL.HEIGHT,
   showImageCaption = false,
 }: ScanMyContactQRProps) => {
   return (

--- a/components/shared/constants.ts
+++ b/components/shared/constants.ts
@@ -10,8 +10,14 @@ export const PHOTO_DIMENSIONS = {
 } as const
 
 export const QR_CODE = {
-  WIDTH: 296,
-  HEIGHT: 296,
+  SMALL: {
+    WIDTH: 256,
+    HEIGHT: 256,
+  },
+  LARGE: {
+    WIDTH: 396,
+    HEIGHT: 396,
+  },
 } as const
 
 export const SKILL_CARD_IMAGE = {

--- a/localization/english.ts
+++ b/localization/english.ts
@@ -192,7 +192,7 @@ export const RESUME = {
   openToNetworking: 'Networking',
   scanQR: 'Scan My\u00A0Contact',
   feelFreeTo: 'Feel free to\u00A0scan my contact.',
-  regardingJobOpportunities: 'to\u00A0hir\u00A0 me.',
+  regardingJobOpportunities: 'to\u00A0hire\u00A0me.',
   forNetworkingOnLinkedIn: 'to\u00A0network.',
   callMe: 'Call\u00A0me',
   sendAnEmail: 'send\u00A0an\u00A0email',

--- a/localization/english.ts
+++ b/localization/english.ts
@@ -1,5 +1,5 @@
 import { COUNTRY } from '@/__tests__/playwright/lib/utils/constants/ids/dataTestIds'
-import { EM_DASH, EN_DASH } from '@/lib/utils/constants/specialCharacters'
+import { EM_DASH } from '@/lib/utils/constants/specialCharacters'
 import { YEARS } from '@/lib/utils/constants/yearsExperience'
 
 export const ICON_EMOJI = {
@@ -191,9 +191,9 @@ export const RESUME = {
   openToWork: 'Open To\u00A0work',
   openToNetworking: 'Networking',
   scanQR: 'Scan My\u00A0Contact',
-  feelFreeTo: 'Feel free to scan my contact.',
-  regardingJobOpportunities: 'to hire me.',
-  forNetworkingOnLinkedIn: 'for networking.',
+  feelFreeTo: 'Feel free to\u00A0scan my contact.',
+  regardingJobOpportunities: 'to\u00A0hir\u00A0 me.',
+  forNetworkingOnLinkedIn: 'to\u00A0network.',
   callMe: 'Call\u00A0me',
   sendAnEmail: 'send\u00A0an\u00A0email',
   connectOnLinkedIn: 'connect on\u00A0LinkedIn',
@@ -201,7 +201,7 @@ export const RESUME = {
 
 export const CAREER_PATH = {
   heading: 'Career Path',
-  text1: `My path to\u00A0become a\u00A0full${EN_DASH}time`,
+  text1: `My path over the\u00A0years to\u00A0become a\u00A0freelance`,
   text2: COMMON_VALUES.reactDeveloperNBSP,
 }
 


### PR DESCRIPTION
This pull request introduces improvements to the QR code display on the resume contact page, updates spacing in the career path section, and refines several English localization strings for clarity and consistency. The most notable changes are grouped below:

**QR Code Display Enhancements:**
* Added support for multiple QR code sizes by updating the `QR_CODE` constant to include `SMALL` and `LARGE` variants, and refactored the `ScanMyContactQR` component to use these sizes as defaults and props. The resume contact page now displays a larger QR code. [[1]](diffhunk://#diff-8f1a912933f947bbaed84a495de58eb37ce610598be405c875144e14b0000584L13-R20) [[2]](diffhunk://#diff-0bf9f4dbaf2411abefd166a6d8731af813854fcb1df39c72431fdf8667298bc2L14-R15) [[3]](diffhunk://#diff-170593d34b1618224719de15d6e0d08013c7eb2d729bee303a7e349bee41188eR8) [[4]](diffhunk://#diff-170593d34b1618224719de15d6e0d08013c7eb2d729bee303a7e349bee41188eL33-R38)

**UI Spacing Improvements:**
* Increased vertical spacing (`gap`) between elements in the `CareerPath` section to enhance readability and layout.

**Localization and Copy Updates:**
* Updated several English localization strings in the resume section to use non-breaking spaces and improved phrasing for better clarity and formatting.
* Removed unused import of `EN_DASH` from the localization file.