### PR TITLE
refactor(tailwind): 👷 config styling system

### DIFF
--- a/components/layout/footer/Copyright.tsx
+++ b/components/layout/footer/Copyright.tsx
@@ -11,7 +11,7 @@ import { getCurrentYear } from '@/lib/utils/helpers/years/getCurrentYear'
 
 const Copyright = () => {
   return (
-    <Paragraph size="text-md" marginTop="mt-4" customCss="flex flex-row text-center gap-2">
+    <Paragraph size="text-base" marginTop="mt-4" customCss="flex flex-row text-center gap-2">
       <span data-testid={DATA_TEST_IDS.footer.copyright}>
         {COPYRIGHT}
         {'\u00A0'}

--- a/components/layout/header/Logo.tsx
+++ b/components/layout/header/Logo.tsx
@@ -34,7 +34,7 @@ const Logo = () => {
         </div>
         <Paragraph
           marginTop="mt-0"
-          size="text-md"
+          size="text-base"
           customCss="select-none cursor-pointer font-bold group-hover:text-violet-800"
         >
           {TEXT.logo}

--- a/components/layout/header/menu/MenuItem.tsx
+++ b/components/layout/header/menu/MenuItem.tsx
@@ -9,7 +9,7 @@ const MenuItem = ({ linkItem, isMobile, onClickLink }: MenuItemProps) => {
   const mobileDesktopCSS = isMobile ? 'py-3' : 'py-2'
   const hoverAndFocusCSS = 'hover:border-violet-50 hover:bg-violet-50'
   const sharedCss =
-    'text-md block select-none rounded-lg px-4 lg:px-3 xl:px-4 bg-neutral-50 font-bold transition-all duration-200 ease-in-out'
+    'text-base block select-none rounded-lg px-4 lg:px-3 xl:px-4 bg-neutral-50 font-bold transition-all duration-200 ease-in-out'
 
   // Active state styling
   const activeCSS = isActive

--- a/components/pages/home/skills/Skills.tsx
+++ b/components/pages/home/skills/Skills.tsx
@@ -30,7 +30,7 @@ const Skills = () => {
       <div className="mt-4 flex flex-col items-center">
         <Paragraph
           textColor="text-neutral-600"
-          size="text-md"
+          size="text-base"
           customCss="w-[270px] text-center italic md:w-[520px]"
         >
           {TEXT.skillsIconsNames}

--- a/components/pages/projects/other-experience/ExperienceCard.tsx
+++ b/components/pages/projects/other-experience/ExperienceCard.tsx
@@ -14,7 +14,7 @@ const ExperienceCard = ({ company, role, description }: ExperienceCardProps) => 
         <span className="mx-1">{MIDDLE_DOT}</span>
         <Highlight text={role} />
       </Heading>
-      <Paragraph marginTop="mt-0" size="text-md" textColor="text-neutral-600">
+      <Paragraph marginTop="mt-0" size="text-base" textColor="text-neutral-600">
         {description}
       </Paragraph>
     </div>

--- a/components/shared/SkillCardTechnologyYears.tsx
+++ b/components/shared/SkillCardTechnologyYears.tsx
@@ -9,7 +9,7 @@ const SkillCardTechnologyYears = ({ technology, years }: SkillCardTechnologyYear
         {technology}
       </div>
       {years && (
-        <div className="text-md tracking-tight text-neutral-600 md:text-xl">
+        <div className="text-base tracking-tight text-neutral-600 md:text-xl">
           {years} {getYearsText(years)}
         </div>
       )}

--- a/lib/utils/typeDefinitions/types.ts
+++ b/lib/utils/typeDefinitions/types.ts
@@ -59,7 +59,7 @@ export type TextColorType = 'text-neutral-600' | 'text-neutral-700' | 'text-neut
 // Define possible text sizes
 export type TextSizeType =
   | 'text-sm'
-  | 'text-md'
+  | 'text-base'
   | 'text-lg'
   | 'text-xl'
   | 'text-2xl'

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,8 +1,8 @@
 import type { Config } from 'tailwindcss'
 
-// Extend the Config type to include safelist
+// Extend the Config type to include safelist with pattern support
 type ExtendedConfig = Config & {
-  safelist?: string[]
+  safelist?: (string | { pattern: RegExp })[]
 }
 
 // Custom colors for the project
@@ -101,70 +101,15 @@ const config: ExtendedConfig = {
   plugins: [],
 
   // 4. Safelist - classes always included in final CSS (for dynamic classes)
+  // Using pattern-based approach for better maintainability and scalability
   safelist: [
-    // Background colors
-    'bg-blue-100',
-    'bg-blue-600',
-    'bg-gray-600',
-    'bg-gray-800',
-    'bg-green-100',
-    'bg-green-600',
-    'bg-neutral-100',
-    'bg-red-100',
-    'bg-red-600',
-    'bg-yellow-100',
-    'bg-yellow-600',
-
-    // Border colors
-    'border-blue-300',
-    'border-green-300',
-    'border-neutral-300',
-    'border-red-300',
-    'border-yellow-300',
-
-    // Focus ring colors
-    'focus:ring-blue-300',
-    'focus:ring-blue-400',
-    'focus:ring-gray-300',
-    'focus:ring-gray-400',
-    'focus:ring-green-400',
-    'focus:ring-red-300',
-    'focus:ring-red-400',
-    'focus:ring-yellow-400',
-
-    // Hover background colors
-    'hover:bg-blue-800',
-    'hover:bg-gray-800',
-    'hover:bg-green-800',
-    'hover:bg-red-800',
-    'hover:bg-yellow-800',
-
-    // Responsive text sizes
-    'sm:text-6xl',
-    'sm:text-9xl',
-    'md:text-7xl',
-    'lg:text-9xl',
-
-    // Base text sizes
-    'text-sm',
-    'text-md',
-    'text-lg',
-    'text-xl',
-    'text-2xl',
-    'text-3xl',
-    'text-4xl',
-    'text-5xl',
-    'text-6xl',
-    'text-7xl',
-    'text-8xl',
-    'text-9xl',
-
-    // Text colors
-    'text-blue-800',
-    'text-green-800',
-    'text-neutral-800',
-    'text-red-800',
-    'text-yellow-800',
+    { pattern: /bg-(blue|gray|green|neutral|red|yellow)-(100|600|800)/ }, // Background colors
+    { pattern: /border-(blue|green|neutral|red|yellow)-300/ }, // Border colors
+    { pattern: /focus:ring-(blue|gray|green|red|yellow)-(300|400)/ }, // Focus ring colors
+    { pattern: /hover:bg-(blue|gray|green|red|yellow)-800/ }, // Hover background colors
+    { pattern: /text-(blue|green|neutral|red|yellow)-800/ }, // Text colors
+    { pattern: /text-(xs|sm|base|lg|xl|2xl|3xl|4xl|5xl|6xl|7xl|8xl|9xl)/ }, // Text sizes
+    { pattern: /(sm|md|lg):text-(6xl|7xl|9xl)/ }, // Responsive text sizes
   ],
 }
 


### PR DESCRIPTION
## Issue: https://github.com/krsiakdaniel/portfolio-website-krsiak-cz/issues/664

This pull request standardizes the text size across multiple components by replacing the custom `text-md` size with Tailwind's default `text-base`. It also updates the Tailwind configuration to use pattern-based safelisting for CSS classes, improving maintainability and scalability.

**Text size standardization:**
* Replaced all occurrences of `text-md` with `text-base` in components such as `Copyright`, `Logo`, `MenuItem`, `Skills`, `ExperienceCard`, and `SkillCardTechnologyYears` to align with Tailwind's default sizing. [[1]](diffhunk://#diff-516e2ca92754d6abd4733f79470c43e3e5d5e3c18c2e2cbffc59df7e837a583aL14-R14) [[2]](diffhunk://#diff-84925a894231f3fc27b16259ad44855a0e615f6206352b441fb00e985dac480eL37-R37) [[3]](diffhunk://#diff-cf976ffd9d98acff84ee60772f1f7feeaf9a18a395c05b1a7a25999198d1e154L12-R12) [[4]](diffhunk://#diff-af50c94e8e4ae0cf3f6876d1ce08986fc8bca01b06eeb1faf9cc074651b39745L33-R33) [[5]](diffhunk://#diff-be739d42554b6618fea81cfb80aca00034ff650d1acce761fc83872aa5d0e662L17-R17) [[6]](diffhunk://#diff-d87ade6a0bfce225c1b9eafa4b88ab7f6ee128bd71737bb0929ac35887195014L12-R12)
* Updated the `TextSizeType` type definition to remove `text-md` and add `text-base`.

**Tailwind configuration improvements:**
* Modified the `ExtendedConfig` type in `tailwind.config.ts` to support safelist entries as either strings or RegExp patterns.
* Replaced the explicit list of safelisted classes with pattern-based safelisting for backgrounds, borders, focus rings, hover states, text colors, and text sizes, making the configuration more scalable and easier to maintain.