### PR TITLE
aria(emoji): ♿ add missing aria attributes

### DIFF
--- a/app/testimonials/page.tsx
+++ b/app/testimonials/page.tsx
@@ -51,6 +51,7 @@ const Testimonials = () => {
         <TestimonialsSection
           title={TESTIMONIALS.sections.professional.title}
           icon={ICON_EMOJI.manTechnologist.lightSkinTone}
+          iconAria={ARIA_LABELS.emoji.manTechnologist.lightSkinTone}
           description={TESTIMONIALS.sections.professional.description}
           testimonials={workTestimonials}
         />
@@ -59,6 +60,7 @@ const Testimonials = () => {
         <TestimonialsSection
           title={TESTIMONIALS.sections.character.title}
           icon={ICON_EMOJI.foldedHands}
+          iconAria={ARIA_LABELS.emoji.foldedHands}
           description={TESTIMONIALS.sections.character.description}
           testimonials={personalTestimonials}
         />
@@ -67,6 +69,7 @@ const Testimonials = () => {
         <TestimonialsSection
           title={TESTIMONIALS.sections.fitnessCoach.title}
           icon={ICON_EMOJI.personLiftingWeights}
+          iconAria={ARIA_LABELS.emoji.personLiftingWeights}
           description={TESTIMONIALS.sections.fitnessCoach.description}
           testimonials={fitnessCoachTestimonials}
         />

--- a/app/who-i-am/page.tsx
+++ b/app/who-i-am/page.tsx
@@ -44,7 +44,11 @@ const WhoIAm = () => {
         </section>
 
         <section>
-          <HeadingSection text={SOUTH_KOREA.headingTravel} icon={ICON_EMOJI.airplane} />
+          <HeadingSection
+            text={SOUTH_KOREA.headingTravel}
+            icon={ICON_EMOJI.airplane}
+            iconAria={ARIA_LABELS.emoji.airplane}
+          />
           <Paragraph>
             <span>{WHO_I_AM.aboutMe}</span>
           </Paragraph>

--- a/components/pages/testimonials/TestimonialsSection.tsx
+++ b/components/pages/testimonials/TestimonialsSection.tsx
@@ -7,11 +7,12 @@ import { TestimonialsSectionProps } from '@/lib/utils/typeDefinitions/props/page
 const TestimonialsSection = ({
   title,
   icon = '',
+  iconAria = '',
   description,
   testimonials = [],
 }: TestimonialsSectionProps) => (
   <div className="mt-20">
-    <HeadingSection text={title} icon={icon} />
+    <HeadingSection text={title} icon={icon} iconAria={iconAria} />
     <TestimonialDescription description={description} />
     <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
       {testimonials.map((testimonial) => (

--- a/components/pages/who-i-am/SouthKorea.tsx
+++ b/components/pages/who-i-am/SouthKorea.tsx
@@ -21,7 +21,11 @@ const SouthKorea = () => {
 
   return (
     <section>
-      <HeadingSection text={SOUTH_KOREA.headingSouthKorea} icon={ICON_EMOJI.flagSouthKorea} />
+      <HeadingSection
+        text={SOUTH_KOREA.headingSouthKorea}
+        icon={ICON_EMOJI.flagSouthKorea}
+        iconAria={ARIA_LABELS.emoji.flag.southKorea}
+      />
 
       <Paragraph>
         <span>{SOUTH_KOREA.introduction}</span>

--- a/components/pages/who-i-am/WhoIAmTravelsList.tsx
+++ b/components/pages/who-i-am/WhoIAmTravelsList.tsx
@@ -7,9 +7,11 @@ const WhoIAmTravelsList = () => {
   return (
     <div className="mt-4">
       <List>
-        {travelItems.map(({ id, flag, text }) => (
+        {travelItems.map(({ id, icon, iconAria, text }) => (
           <ListItem key={id} showIcon={false}>
-            <span>{flag}</span>
+            <span role="img" aria-label={iconAria}>
+              {icon}
+            </span>
             <span className="ml-2">{text}</span>
           </ListItem>
         ))}

--- a/components/shared/HeadingSection.tsx
+++ b/components/shared/HeadingSection.tsx
@@ -3,11 +3,11 @@ import Heading from '@/components/shared/Heading'
 import { CSS_GLOBAL_CLASSES } from '@/lib/utils/constants/cssGlobalClasses'
 
 import { HeadingSectionProps } from '@/lib/utils/typeDefinitions/props/shared/heading-section'
-import { ARIA_LABELS } from '@/localization/english'
 
 const HeadingSection = ({
   text = '',
   icon = '',
+  iconAria = '',
   id = '',
   dataTestId = '',
 }: HeadingSectionProps) => {
@@ -21,7 +21,7 @@ const HeadingSection = ({
     >
       <span className="flex items-start space-x-2 md:items-center">
         {icon && (
-          <span role="img" aria-label={ARIA_LABELS.emoji.icon} className="inline-flex text-4xl">
+          <span role="img" aria-label={iconAria} className="inline-flex text-4xl">
             {icon}
           </span>
         )}

--- a/lib/data/pages/who-i-am/travelItems.ts
+++ b/lib/data/pages/who-i-am/travelItems.ts
@@ -1,26 +1,30 @@
 import { TravelItem } from '@/lib/utils/typeDefinitions/interfaces'
 
-import { ICON_EMOJI, WHO_I_AM } from '@/localization/english'
+import { ARIA_LABELS, ICON_EMOJI, WHO_I_AM } from '@/localization/english'
 
 export const travelItems: TravelItem[] = [
   {
     id: WHO_I_AM.idCZ,
-    flag: ICON_EMOJI.flagCzechRepublic,
+    icon: ICON_EMOJI.flagCzechRepublic,
+    iconAria: ARIA_LABELS.emoji.flag.czechRepublic,
     text: WHO_I_AM.textCzechRepublic,
   },
   {
     id: WHO_I_AM.idSK,
-    flag: ICON_EMOJI.flagSlovakia,
+    icon: ICON_EMOJI.flagSlovakia,
+    iconAria: ARIA_LABELS.emoji.flag.slovakia,
     text: WHO_I_AM.textSlovakia,
   },
   {
     id: WHO_I_AM.idFI,
-    flag: ICON_EMOJI.flagAlandIslands,
+    icon: ICON_EMOJI.flagAlandIslands,
+    iconAria: ARIA_LABELS.emoji.flag.alandIslands,
     text: WHO_I_AM.textAlandIslands,
   },
   {
     id: WHO_I_AM.idKR,
-    flag: ICON_EMOJI.flagSouthKorea,
+    icon: ICON_EMOJI.flagSouthKorea,
+    iconAria: ARIA_LABELS.emoji.flag.southKorea,
     text: WHO_I_AM.textKorea,
   },
 ]

--- a/lib/utils/typeDefinitions/interfaces.ts
+++ b/lib/utils/typeDefinitions/interfaces.ts
@@ -424,7 +424,8 @@ export interface CareerPathStep {
 // Travel Item
 export interface TravelItem {
   id: string
-  flag: string
+  icon: string
+  iconAria: string
   text: string
 }
 

--- a/lib/utils/typeDefinitions/props/pages/testimonials.ts
+++ b/lib/utils/typeDefinitions/props/pages/testimonials.ts
@@ -39,6 +39,7 @@ export type TestimonialPersonInfoProps = {
 export type TestimonialsSectionProps = {
   title: string
   icon?: string
+  iconAria?: string
   description: string
   testimonials: TestimonialItem[]
 }

--- a/lib/utils/typeDefinitions/props/shared/heading-section.ts
+++ b/lib/utils/typeDefinitions/props/shared/heading-section.ts
@@ -2,7 +2,7 @@
 export type HeadingSectionProps = {
   text: string | React.ReactNode
   icon?: string
-  iconAria: string
+  iconAria?: string
   id?: string
   dataTestId?: string
 }

--- a/lib/utils/typeDefinitions/props/shared/heading-section.ts
+++ b/lib/utils/typeDefinitions/props/shared/heading-section.ts
@@ -2,6 +2,7 @@
 export type HeadingSectionProps = {
   text: string | React.ReactNode
   icon?: string
+  iconAria: string
   id?: string
   dataTestId?: string
 }


### PR DESCRIPTION
## issue: https://github.com/krsiakdaniel/portfolio-website-krsiak-cz/issues/698

This pull request improves accessibility across several components by adding support for custom ARIA labels for emoji icons. This ensures that screen readers can provide more descriptive information about the icons, making the site more inclusive for users with assistive technologies. The changes affect testimonial, travel, and heading sections, updating both the data structures and component props to pass and utilize ARIA labels.

**Accessibility improvements:**

* Updated `HeadingSection` and `TestimonialsSection` components to accept and use a custom `iconAria` prop for emoji icons, replacing hardcoded ARIA labels with context-specific ones. [[1]](diffhunk://#diff-523c6981162a488dd20bf54e772c6b2040ad0081fa112190f8b36090b7fff24dL24-R24) [[2]](diffhunk://#diff-459a5d04b50930519477e543bd0491791cf4a79358036809270735313394e7dfR10-R15) [[3]](diffhunk://#diff-bf63e4892ef5fdf577cb850e621c91ccc9a6588c5308760b6960ba16ef39310bR42) [[4]](diffhunk://#diff-3e8c0b2a00871a80251486bec9b19c44f06debc7c0f022d87752fb3218ad5e65R5)
* Modified travel-related data (`travelItems`) to replace the `flag` property with `icon` and add an `iconAria` field, updating the interface and all usages to support ARIA labels for each travel icon. [[1]](diffhunk://#diff-aafae547d1d4961667819341499a3844ce0f6c65b902319b30a483025ccd7852L3-R27) [[2]](diffhunk://#diff-3a45246eb153b15b836da4fc4ca195c36b8e3d8b02fe21bc414601968045a41aL427-R428) [[3]](diffhunk://#diff-3e19a5bfb32bfaa4a746e9981b74d5bf0ba6e939a30904357e66bde7361161b5L10-R14)

**Component usage updates:**

* Updated all usages of `HeadingSection` and `TestimonialsSection` in testimonial and "Who I Am" pages to pass the appropriate ARIA labels for their icons. [[1]](diffhunk://#diff-2b61d18bfe1049b2242d467f60e460ffa76ce28d0864a825f66b2682d512d883R54) [[2]](diffhunk://#diff-2b61d18bfe1049b2242d467f60e460ffa76ce28d0864a825f66b2682d512d883R63) [[3]](diffhunk://#diff-2b61d18bfe1049b2242d467f60e460ffa76ce28d0864a825f66b2682d512d883R72) [[4]](diffhunk://#diff-a3bd0b6835cf12b09e07240104d5d8b08ae75fb144d91bead9c2cf8fd1afa54dL47-R51) [[5]](diffhunk://#diff-6cf99c6b184af05392086190de7f4f8882c31e468e6f51a26073d99b40a8fd6fL24-R28)

These changes collectively enhance the accessibility and semantic correctness of icon usage throughout the site.