### PR TITLE
refactor(next): 👷 metadata type

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Viewport } from 'next'
+import type { Metadata, Viewport } from 'next'
 
 import GoogleAnalytics from '@/components/analytics/GoogleAnalytics'
 import AppleTouchIcons from '@/components/layout/AppleTouchIcons'
@@ -19,7 +19,7 @@ import './globals.css'
 import 'react-tooltip/dist/react-tooltip.css'
 
 // Default metadata used by all pages if they don't have their own metadata
-export const metadata = {
+export const metadata: Metadata = {
   ...defaultMetaData,
 }
 // Viewport settings for the entire application

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,5 @@
+import { Metadata } from 'next'
+
 import PageContainer from '@/components/layout/PageContainer'
 import PageNavigation from '@/components/layout/page-navigation/PageNavigation'
 import Companies from '@/components/pages/home/Companies'
@@ -17,7 +19,7 @@ import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/da
 
 import { ICON_EMOJI, TEXT } from '@/localization'
 
-export const metadata = {
+export const metadata: Metadata = {
   ...metaDataHome,
 }
 

--- a/app/personal-projects/cryptomania/page.tsx
+++ b/app/personal-projects/cryptomania/page.tsx
@@ -1,3 +1,5 @@
+import { Metadata } from 'next'
+
 import PageNavigation from '@/components/layout/page-navigation/PageNavigation'
 import ProjectPageLayoutWrapper from '@/components/layout/projects/ProjectPageLayoutWrapper'
 import Alert from '@/components/shared/Alert'
@@ -18,7 +20,7 @@ import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/da
 
 import { ICON_EMOJI, PROJECT_CRYPTOMANIA, TEXT } from '@/localization'
 
-export const metadata = {
+export const metadata: Metadata = {
   ...metaDataCryptomania,
 }
 

--- a/app/personal-projects/krsiak/page.tsx
+++ b/app/personal-projects/krsiak/page.tsx
@@ -1,3 +1,5 @@
+import { Metadata } from 'next'
+
 import PageNavigation from '@/components/layout/page-navigation/PageNavigation'
 import ProjectPageLayoutWrapper from '@/components/layout/projects/ProjectPageLayoutWrapper'
 
@@ -15,7 +17,7 @@ import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/da
 
 import { ICON_EMOJI, TEXT } from '@/localization'
 
-export const metadata = {
+export const metadata: Metadata = {
   ...metaDataKrsiak,
 }
 

--- a/app/personal-projects/page.tsx
+++ b/app/personal-projects/page.tsx
@@ -1,3 +1,5 @@
+import { Metadata } from 'next'
+
 import PageContainer from '@/components/layout/PageContainer'
 import PageNavigation from '@/components/layout/page-navigation/PageNavigation'
 import ProjectsOverviewLayout from '@/components/layout/projects/ProjectsOverviewLayout'
@@ -17,7 +19,7 @@ import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/da
 
 import { ARIA_LABELS, ICON_EMOJI, TEXT } from '@/localization'
 
-export const metadata = {
+export const metadata: Metadata = {
   ...metaDataPersonalProjects,
 }
 

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -1,3 +1,5 @@
+import { Metadata } from 'next'
+
 import PageContainer from '@/components/layout/PageContainer'
 import PageNavigation from '@/components/layout/page-navigation/PageNavigation'
 import CareerPath from '@/components/pages/resume/CareerPath'
@@ -17,7 +19,7 @@ import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/da
 
 import { ARIA_LABELS, ICON_EMOJI, TEXT } from '@/localization'
 
-export const metadata = {
+export const metadata: Metadata = {
   ...metaDataResume,
 }
 

--- a/app/status/page.tsx
+++ b/app/status/page.tsx
@@ -1,3 +1,5 @@
+import { Metadata } from 'next'
+
 import PageContainer from '@/components/layout/PageContainer'
 import StatusIntroduction from '@/components/pages/status/StatusIntroduction'
 import BreadCrumbs from '@/components/shared/Breadcrumbs'
@@ -19,7 +21,7 @@ import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/da
 
 import { ARIA_LABELS, ICON_EMOJI, IMAGE_ALT, STATUS, TEXT } from '@/localization'
 
-export const metadata = {
+export const metadata: Metadata = {
   ...metaDataStatus,
 }
 

--- a/app/testimonials/page.tsx
+++ b/app/testimonials/page.tsx
@@ -1,3 +1,5 @@
+import { Metadata } from 'next'
+
 import PageContainer from '@/components/layout/PageContainer'
 import PageNavigation from '@/components/layout/page-navigation/PageNavigation'
 import TestimonialsIntroduction from '@/components/pages/testimonials/TestimonialsIntroduction'
@@ -18,7 +20,7 @@ import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/da
 
 import { ARIA_LABELS, ICON_EMOJI, TESTIMONIALS, TEXT } from '@/localization'
 
-export const metadata = {
+export const metadata: Metadata = {
   ...metaDataTestimonials,
 }
 

--- a/app/who-i-am/page.tsx
+++ b/app/who-i-am/page.tsx
@@ -1,3 +1,5 @@
+import { Metadata } from 'next'
+
 import PageContainer from '@/components/layout/PageContainer'
 import PageNavigation from '@/components/layout/page-navigation/PageNavigation'
 import SouthKorea from '@/components/pages/who-i-am/SouthKorea'
@@ -17,7 +19,7 @@ import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/da
 
 import { ARIA_LABELS, ICON_EMOJI, SOUTH_KOREA, TEXT, WHO_I_AM } from '@/localization'
 
-export const metadata = {
+export const metadata: Metadata = {
   ...metaDataWhoIam,
 }
 

--- a/app/work-experience/groupon/page.tsx
+++ b/app/work-experience/groupon/page.tsx
@@ -1,3 +1,5 @@
+import { Metadata } from 'next'
+
 import PageNavigation from '@/components/layout/page-navigation/PageNavigation'
 import ProjectPageLayoutWrapper from '@/components/layout/projects/ProjectPageLayoutWrapper'
 
@@ -15,7 +17,7 @@ import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/da
 
 import { ICON_EMOJI, TEXT } from '@/localization'
 
-export const metadata = {
+export const metadata: Metadata = {
   ...metaDataGroupon,
 }
 

--- a/app/work-experience/komercni-banka/page.tsx
+++ b/app/work-experience/komercni-banka/page.tsx
@@ -1,3 +1,5 @@
+import { Metadata } from 'next'
+
 import PageNavigation from '@/components/layout/page-navigation/PageNavigation'
 import ProjectPageLayoutWrapper from '@/components/layout/projects/ProjectPageLayoutWrapper'
 
@@ -15,7 +17,7 @@ import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/da
 
 import { ICON_EMOJI, TEXT } from '@/localization'
 
-export const metadata = {
+export const metadata: Metadata = {
   ...metaDataKomercniBanka,
 }
 

--- a/app/work-experience/kooperativa/page.tsx
+++ b/app/work-experience/kooperativa/page.tsx
@@ -1,3 +1,5 @@
+import { Metadata } from 'next'
+
 import PageNavigation from '@/components/layout/page-navigation/PageNavigation'
 import ProjectPageLayoutWrapper from '@/components/layout/projects/ProjectPageLayoutWrapper'
 
@@ -15,7 +17,7 @@ import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/da
 
 import { ICON_EMOJI, TEXT } from '@/localization'
 
-export const metadata = {
+export const metadata: Metadata = {
   ...metaDataKooperativa,
 }
 

--- a/app/work-experience/moravia/page.tsx
+++ b/app/work-experience/moravia/page.tsx
@@ -1,3 +1,5 @@
+import { Metadata } from 'next'
+
 import PageNavigation from '@/components/layout/page-navigation/PageNavigation'
 import ProjectPageLayoutWrapper from '@/components/layout/projects/ProjectPageLayoutWrapper'
 
@@ -15,7 +17,7 @@ import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/da
 
 import { ICON_EMOJI, TEXT } from '@/localization'
 
-export const metadata = {
+export const metadata: Metadata = {
   ...metaDataMoravia,
 }
 

--- a/app/work-experience/page.tsx
+++ b/app/work-experience/page.tsx
@@ -1,3 +1,5 @@
+import { Metadata } from 'next'
+
 import PageContainer from '@/components/layout/PageContainer'
 import PageNavigation from '@/components/layout/page-navigation/PageNavigation'
 import ProjectsOverviewLayout from '@/components/layout/projects/ProjectsOverviewLayout'
@@ -25,7 +27,7 @@ import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/da
 
 import { ARIA_LABELS, COMMON_VALUES, ICON_EMOJI, TEXT } from '@/localization'
 
-export const metadata = {
+export const metadata: Metadata = {
   ...metaDataWorkExperience,
 }
 

--- a/app/work-experience/smartsupp-dashboard/page.tsx
+++ b/app/work-experience/smartsupp-dashboard/page.tsx
@@ -1,3 +1,5 @@
+import { Metadata } from 'next'
+
 import PageNavigation from '@/components/layout/page-navigation/PageNavigation'
 import ProjectPageLayoutWrapper from '@/components/layout/projects/ProjectPageLayoutWrapper'
 
@@ -15,7 +17,7 @@ import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/da
 
 import { ICON_EMOJI, TEXT } from '@/localization'
 
-export const metadata = {
+export const metadata: Metadata = {
   ...metaDataSmartsuppDashboard,
 }
 

--- a/app/work-experience/smartsupp-help/page.tsx
+++ b/app/work-experience/smartsupp-help/page.tsx
@@ -1,3 +1,5 @@
+import { Metadata } from 'next'
+
 import PageNavigation from '@/components/layout/page-navigation/PageNavigation'
 import ProjectPageLayoutWrapper from '@/components/layout/projects/ProjectPageLayoutWrapper'
 
@@ -15,7 +17,7 @@ import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/da
 
 import { ICON_EMOJI, TEXT } from '@/localization'
 
-export const metadata = {
+export const metadata: Metadata = {
   ...metaDataSmartsuppHelp,
 }
 

--- a/app/work-experience/smartsupp-web/page.tsx
+++ b/app/work-experience/smartsupp-web/page.tsx
@@ -1,3 +1,5 @@
+import { Metadata } from 'next'
+
 import PageNavigation from '@/components/layout/page-navigation/PageNavigation'
 import ProjectPageLayoutWrapper from '@/components/layout/projects/ProjectPageLayoutWrapper'
 
@@ -15,7 +17,7 @@ import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/da
 
 import { ICON_EMOJI, TEXT } from '@/localization'
 
-export const metadata = {
+export const metadata: Metadata = {
   ...metaDataSmartsuppWeb,
 }
 


### PR DESCRIPTION
This pull request standardizes the use of type annotations for page metadata throughout the application. Specifically, it updates all page files to explicitly type their `metadata` exports as `Metadata` from `next`, improving type safety and consistency across the codebase.

**Type safety and consistency improvements:**

* Added explicit `import { Metadata } from 'next'` and typed all `metadata` exports as `Metadata` in every page file, including `app/layout.tsx`, `app/page.tsx`, and all subpages (e.g., personal projects, work experience, resume, testimonials, status, who-i-am) to ensure uniform typing and better maintainability. [[1]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bL1-R1) [[2]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bL22-R22) [[3]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R1-R2) [[4]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L20-R22) [[5]](diffhunk://#diff-b09125485005878f47b8e859ef12c15af5e4cf97792bcaa2c613d07b2cb87ca7R1-R2) [[6]](diffhunk://#diff-b09125485005878f47b8e859ef12c15af5e4cf97792bcaa2c613d07b2cb87ca7L21-R23) [[7]](diffhunk://#diff-dcf33066b75cae80f6fc82e6b33f83693fbe43bbcccdd33a61d5011d7edcf191R1-R2) [[8]](diffhunk://#diff-dcf33066b75cae80f6fc82e6b33f83693fbe43bbcccdd33a61d5011d7edcf191L18-R20) [[9]](diffhunk://#diff-50a0652ed34061a594777f59a4adc49579a1e9a3396e14e79db8f32d71faaa9bR1-R2) [[10]](diffhunk://#diff-50a0652ed34061a594777f59a4adc49579a1e9a3396e14e79db8f32d71faaa9bL20-R22) [[11]](diffhunk://#diff-a5b785c3ffb49da984a7500ded3bac0c137dd04408950109151ba71e63aeea8aR1-R2) [[12]](diffhunk://#diff-a5b785c3ffb49da984a7500ded3bac0c137dd04408950109151ba71e63aeea8aL20-R22) [[13]](diffhunk://#diff-624f21a50731a7b4a690ed7a681c1b1d2f11ff1f790ed5d1533eb214d0099a0dR1-R2) [[14]](diffhunk://#diff-624f21a50731a7b4a690ed7a681c1b1d2f11ff1f790ed5d1533eb214d0099a0dL22-R24) [[15]](diffhunk://#diff-2b61d18bfe1049b2242d467f60e460ffa76ce28d0864a825f66b2682d512d883R1-R2) [[16]](diffhunk://#diff-2b61d18bfe1049b2242d467f60e460ffa76ce28d0864a825f66b2682d512d883L21-R23) [[17]](diffhunk://#diff-a3bd0b6835cf12b09e07240104d5d8b08ae75fb144d91bead9c2cf8fd1afa54dR1-R2) [[18]](diffhunk://#diff-a3bd0b6835cf12b09e07240104d5d8b08ae75fb144d91bead9c2cf8fd1afa54dL20-R22) [[19]](diffhunk://#diff-f6d1453c820cf1660b4a47387351b40d7c124360a7508a8574ad552706c60fc7R1-R2) [[20]](diffhunk://#diff-f6d1453c820cf1660b4a47387351b40d7c124360a7508a8574ad552706c60fc7L18-R20) [[21]](diffhunk://#diff-e1dfd764e21ab2470c284cf86eb4145626ea0320f9b2bde51b2c05c1500f668dR1-R2) [[22]](diffhunk://#diff-e1dfd764e21ab2470c284cf86eb4145626ea0320f9b2bde51b2c05c1500f668dL18-R20) [[23]](diffhunk://#diff-d8f1c4bc58eeeea743a4cd8024b71005f792447c5f4c96a23690c895cdafe086R1-R2) [[24]](diffhunk://#diff-d8f1c4bc58eeeea743a4cd8024b71005f792447c5f4c96a23690c895cdafe086L18-R20) [[25]](diffhunk://#diff-0892d5f01d042dea71d120da3470470e8f1cbda2d1b92c01b3538c1670c6bf98R1-R2) [[26]](diffhunk://#diff-0892d5f01d042dea71d120da3470470e8f1cbda2d1b92c01b3538c1670c6bf98L18-R20) [[27]](diffhunk://#diff-ac1ae2a09ffe6e73f3a76a2eece4890b351d7f24eddc7771d82b9c2de693612bR1-R2) [[28]](diffhunk://#diff-ac1ae2a09ffe6e73f3a76a2eece4890b351d7f24eddc7771d82b9c2de693612bL28-R30) [[29]](diffhunk://#diff-26236993e6e3739932ee4a42bbd2f319b39128781fe11bc0a4a4b8e42dfea8f0R1-R2) [[30]](diffhunk://#diff-26236993e6e3739932ee4a42bbd2f319b39128781fe11bc0a4a4b8e42dfea8f0L18-R20) [[31]](diffhunk://#diff-09c0b04c71ddc0b11c3bc6c85f7e23fe841db9b88e335929ed3e6c610401aa8bR1-R2) [[32]](diffhunk://#diff-09c0b04c71ddc0b11c3bc6c85f7e23fe841db9b88e335929ed3e6c610401aa8bL18-R20) [[33]](diffhunk://#diff-d953d9ba2857aae09f322586fbaf6dd650e50f5b5248d28074d92b87d4e0123eR1-R2) [[34]](diffhunk://#diff-d953d9ba2857aae09f322586fbaf6dd650e50f5b5248d28074d92b87d4e0123eL18-R20)