### PR TITLE
refactor(experience): 👷 remove website links

### DIFF
--- a/__tests__/playwright/pages/projects/work/projectsWorkO2itsAiPoweredChatDashboard.spec.ts
+++ b/__tests__/playwright/pages/projects/work/projectsWorkO2itsAiPoweredChatDashboard.spec.ts
@@ -1,11 +1,7 @@
 import { expect, test } from '@playwright/test'
 
 import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/dataTestIds'
-import {
-  EXTERNAL_URL,
-  PAGES_URL,
-  PROJECTS_WORK_URLS,
-} from '@/__tests__/playwright/lib/utils/constants/urls/e2eUrls'
+import { EXTERNAL_URL, PAGES_URL } from '@/__tests__/playwright/lib/utils/constants/urls/e2eUrls'
 
 test.describe('Project Work - O2 ITS - AI-Powered Chat Dashboard', () => {
   test('Links', async ({ page }) => {
@@ -14,11 +10,6 @@ test.describe('Project Work - O2 ITS - AI-Powered Chat Dashboard', () => {
     await test.step('Alert LinkedIn link', async () => {
       const alertLink = page.getByTestId(DATA_TEST_IDS.alert.alertLinkLinkedIn)
       await expect(alertLink).toHaveAttribute('href', EXTERNAL_URL.linkedIn)
-    })
-
-    await test.step('Website link', async () => {
-      const link = page.getByRole('link', { name: 'Website', exact: true })
-      await expect(link).toHaveAttribute('href', PROJECTS_WORK_URLS.workO2itsExternal)
     })
   })
 })

--- a/__tests__/playwright/pages/projects/work/projectsWorkO2itsPublicTendersPortal.spec.ts
+++ b/__tests__/playwright/pages/projects/work/projectsWorkO2itsPublicTendersPortal.spec.ts
@@ -1,11 +1,7 @@
 import { expect, test } from '@playwright/test'
 
 import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/dataTestIds'
-import {
-  EXTERNAL_URL,
-  PAGES_URL,
-  PROJECTS_WORK_URLS,
-} from '@/__tests__/playwright/lib/utils/constants/urls/e2eUrls'
+import { EXTERNAL_URL, PAGES_URL } from '@/__tests__/playwright/lib/utils/constants/urls/e2eUrls'
 
 test.describe('Project Work - O2 ITS - Public Tenders Portal', () => {
   test('Links', async ({ page }) => {
@@ -14,11 +10,6 @@ test.describe('Project Work - O2 ITS - Public Tenders Portal', () => {
     await test.step('Alert LinkedIn link', async () => {
       const alertLink = page.getByTestId(DATA_TEST_IDS.alert.alertLinkLinkedIn)
       await expect(alertLink).toHaveAttribute('href', EXTERNAL_URL.linkedIn)
-    })
-
-    await test.step('Website link', async () => {
-      const link = page.getByRole('link', { name: 'Website', exact: true })
-      await expect(link).toHaveAttribute('href', PROJECTS_WORK_URLS.workO2itsExternal)
     })
   })
 })

--- a/components/layout/projects/project-page/ProjectInformation.tsx
+++ b/components/layout/projects/project-page/ProjectInformation.tsx
@@ -13,11 +13,11 @@ const ProjectInformation = ({
   description,
   skillsOverview,
   customers,
-  projectLinks,
+  projectLinks = [],
   linkGitHub,
 }: ProjectInformationProps) => {
-  const hasMoreLinks = projectLinks.length > 1
-  const hasGithub = linkGitHub ? true : false
+  const hasMoreLinks = projectLinks.length > 1 // multiple links → use plural "Links" heading
+  const hasGithub = !!linkGitHub // GitHub repo link is present
 
   return (
     <>

--- a/data/pages/projects/work/projects-overview/workNextO2itsAiPoweredChatDashboard.ts
+++ b/data/pages/projects/work/projects-overview/workNextO2itsAiPoweredChatDashboard.ts
@@ -62,13 +62,6 @@ export const workNextO2itsAiPoweredChatDashboard: Project = {
     },
   ],
   linkText: overview.linkText,
-  projectLinks: [
-    {
-      urlText: overview.projectLinks[0].urlText,
-      url: overview.projectLinks[0].url,
-      dataTestId: overview.projectLinks[0].dataTestId,
-    },
-  ],
   customers: overview.customers,
   linkProjectPage: overview.linkProjectPage,
 }

--- a/data/pages/projects/work/projects-overview/workViteO2itsPublicTendersPortal.ts
+++ b/data/pages/projects/work/projects-overview/workViteO2itsPublicTendersPortal.ts
@@ -55,13 +55,6 @@ export const workViteO2itsPublicTendersPortal: Project = {
     },
   ],
   linkText: overview.linkText,
-  projectLinks: [
-    {
-      urlText: overview.projectLinks[0].urlText,
-      url: overview.projectLinks[0].url,
-      dataTestId: overview.projectLinks[0].dataTestId,
-    },
-  ],
   customers: overview.customers,
   linkProjectPage: overview.linkProjectPage,
 }

--- a/lib/types/interfaces.ts
+++ b/lib/types/interfaces.ts
@@ -85,7 +85,7 @@ export interface Project extends ProjectBase {
   readonly galleryImages: GalleryImage[]
   readonly years?: string
   readonly skillsOverview: Skill[]
-  readonly projectLinks: Link[]
+  readonly projectLinks?: Link[]
   readonly linkGitHub?: string
 }
 

--- a/localization/pages/projects/work-o2its-ai-powered-chat-dashboard.ts
+++ b/localization/pages/projects/work-o2its-ai-powered-chat-dashboard.ts
@@ -1,8 +1,5 @@
 import { NB_HYPHEN } from '@/lib/utils/constants/specialCharacters'
 import { PAGES_URL } from '@/lib/utils/constants/urls/pageUrls'
-import { PROJECTS_WORK_URLS } from '@/lib/utils/constants/urls/projectsUrls'
-
-import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/dataTestIds'
 
 export const PROJECTS_WORK_O2ITS_AI_CHAT_DASHBOARD = {
   sections: {
@@ -39,13 +36,6 @@ export const PROJECTS_WORK_O2ITS_AI_CHAT_DASHBOARD_OVERVIEW = {
   description:
     'I\u00A0built an\u00A0AI-powered chat application dashboard with integrated AI\u00A0tools for\u00A0document analysis.',
   linkText: 'Project details',
-  projectLinks: [
-    {
-      urlText: 'Website',
-      url: PROJECTS_WORK_URLS.workO2itsExternal,
-      dataTestId: DATA_TEST_IDS.links.O2ITS_AI_POWERED_CHAT_DASHBOARD,
-    },
-  ],
   customers: 'Enterprise clients',
   linkProjectPage: PAGES_URL.workO2itsAiPoweredChatDashboard,
 }

--- a/localization/pages/projects/work-o2its-public-tenders-portal.ts
+++ b/localization/pages/projects/work-o2its-public-tenders-portal.ts
@@ -1,7 +1,4 @@
 import { PAGES_URL } from '@/lib/utils/constants/urls/pageUrls'
-import { PROJECTS_WORK_URLS } from '@/lib/utils/constants/urls/projectsUrls'
-
-import { DATA_TEST_IDS } from '@/__tests__/playwright/lib/utils/constants/ids/dataTestIds'
 
 export const PROJECTS_WORK_O2ITS_PUBLIC_TENDERS_PORTAL = {
   sections: {
@@ -38,13 +35,6 @@ export const PROJECTS_WORK_O2ITS_PUBLIC_TENDERS_PORTAL_OVERVIEW = {
   description:
     'I\u00A0designed structured AI\u00A0prompts and\u00A0refactored the\u00A0frontend architecture for\u00A0a\u00A0Public Tenders Portal application.',
   linkText: 'Project details',
-  projectLinks: [
-    {
-      urlText: 'Website',
-      url: PROJECTS_WORK_URLS.workO2itsExternal,
-      dataTestId: DATA_TEST_IDS.links.O2ITS_PUBLIC_TENDERS_PORTAL,
-    },
-  ],
   customers: 'Enterprise clients',
   linkProjectPage: PAGES_URL.workO2itsPublicTendersPortal,
 }


### PR DESCRIPTION
This pull request removes the "Website" link for the "O2 ITS - AI-Powered Chat Dashboard" and "O2 ITS - Public Tenders Portal" projects from both the UI and the associated Playwright tests. It also updates the `Project` interface and related components to make the `projectLinks` property optional and ensures safer handling of its value.

**Removal of project website links:**

- Deleted the "Website" link from both the project overview localization files (`work-o2its-ai-powered-chat-dashboard.ts`, `work-o2its-public-tenders-portal.ts`) and the corresponding project data files (`workNextO2itsAiPoweredChatDashboard.ts`, `workViteO2itsPublicTendersPortal.ts`). [[1]](diffhunk://#diff-9c224b3aed99ab5c3cafac2148a58f857fe1da0ab9cea76f4cddf228e3630373L42-L48) [[2]](diffhunk://#diff-895d1d450b5c94bbbc350f5fe8adef379aeec6c3e16b76e3aaee6657c50e053fL41-L47) [[3]](diffhunk://#diff-158739eeb430bfd3385fb89d30259e2c13371b7ce7de30da855e5d759f45f17cL65-L71) [[4]](diffhunk://#diff-bc73f8f97d7c7cf2585df38d7b0eab7c5cb47dea08a1be418570439f8cd7cd88L58-L64)
- Removed Playwright test steps that verified the presence of the "Website" link for these projects. [[1]](diffhunk://#diff-c695143a86f8ae2e468ac2940915e02d705bf59a5d477e283e795fabe373b854L18-L22) [[2]](diffhunk://#diff-0a5081cd27f6b53639f047609ed38f42de28530de92413836362c9378a5e6b2cL18-L22)

**Code and type safety improvements:**

- Made the `projectLinks` property optional in the `Project` interface to reflect that not all projects will have external links.
- Updated the `ProjectInformation` component to default `projectLinks` to an empty array and to use safer checks for the presence of GitHub links.

**Test and import cleanup:**

- Removed unnecessary imports of URLs and test IDs from test and localization files now that the website links are no longer needed. [[1]](diffhunk://#diff-c695143a86f8ae2e468ac2940915e02d705bf59a5d477e283e795fabe373b854L4-R4) [[2]](diffhunk://#diff-0a5081cd27f6b53639f047609ed38f42de28530de92413836362c9378a5e6b2cL4-R4) [[3]](diffhunk://#diff-9c224b3aed99ab5c3cafac2148a58f857fe1da0ab9cea76f4cddf228e3630373L3-L5) [[4]](diffhunk://#diff-895d1d450b5c94bbbc350f5fe8adef379aeec6c3e16b76e3aaee6657c50e053fL2-L4)